### PR TITLE
Level Generation, Room/Door functionality

### DIFF
--- a/ArrowAnimator.cs
+++ b/ArrowAnimator.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using DG.Tweening;
+
+public class ArrowAnimator : MonoBehaviour
+{
+    [SerializeField] SpriteRenderer ArrowObject;
+    [SerializeField] private Vector3 endPoint;
+    //Up = -0.1f, Down = 0.1f
+    //Left = 0.1f, Right = -0.1f
+
+    void Start()
+    {
+        if(ArrowObject == null) ArrowObject = GetComponent<SpriteRenderer>();
+        //Use endPoint as an offset
+        if(transform.position != Vector3.zero) 
+            endPoint = new Vector3(transform.position.x + endPoint.x, 
+            transform.position.y + endPoint.y, transform.position.z);
+        
+        Active();
+    }
+
+    void Active()
+    {
+        transform.DOMove(endPoint, .5f).SetLoops(-1, LoopType.Yoyo);
+    }
+}

--- a/ArrowAnimator.cs.meta
+++ b/ArrowAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f62f201eb1d0e546a1e0dc18132e8e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Inventory.cs
+++ b/Inventory.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -14,7 +13,6 @@ public class Inventory : MonoBehaviour
 
     private void Start()
     {
-        //TODO: add get
         if (goldCount != null) UpdateGold();
     }
 

--- a/ObjectPoolers/VFXHandler.cs
+++ b/ObjectPoolers/VFXHandler.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class VFXHandler : MonoBehaviour
+{
+    // Enables objects stored in pools
+    // ObjectPoolerList will enable objects if available
+    //  otherwise Instantiates a new object
+    [Header("Pooled Objects")]
+    [SerializeField]
+    private ObjectPoolerList VFXPool;
+
+    private void Start()
+    {
+        if (VFXPool == null) VFXPool = GetComponent<ObjectPoolerList>();
+    }
+
+    public void ShowEffect(Vector3 pos)
+    {
+        GameObject effect = VFXPool.GetObject();
+        effect.transform.position = pos;
+        effect.transform.rotation = Quaternion.identity;
+        effect.SetActive(true);
+    }
+
+    public void ShowEffect(Vector3 pos, float yRotation)
+    {
+        GameObject effect = VFXPool.GetObject();
+        effect.transform.position = pos;
+        effect.transform.rotation = Quaternion.Euler(0, yRotation, 0);
+        effect.SetActive(true);
+    }
+}

--- a/ObjectPoolers/VFXHandler.cs.meta
+++ b/ObjectPoolers/VFXHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 611d67d9e6982fa45b02239034181d0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Animators/PooledObjectAnimator.cs
+++ b/_Animators/PooledObjectAnimator.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PooledObjectAnimator : MonoBehaviour
+{
+    //! - Attach this to the Prefab
+    // Plays an animation from an array of animation names
+    // Once animation is done, object is added to a pool
+    [Header("References")]
+    [SerializeField] ObjectPoolerList pool;
+    [SerializeField] Animator animator;
+    [SerializeField] private string animName;
+    [SerializeField] private float animTime;
+    private GameObject prefab;
+
+    private void Start()
+    {
+        pool = GetComponentInParent<ObjectPoolerList>();
+    }
+
+    private void OnEnable()
+    {
+        animator.Play(animName);
+        StartCoroutine(PoolObject(animTime));
+    }
+
+    IEnumerator PoolObject(float duration)
+    {
+        yield return new WaitForSeconds(duration);
+        pool.ReturnObject(gameObject);
+    }
+}

--- a/_Animators/PooledObjectAnimator.cs.meta
+++ b/_Animators/PooledObjectAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 952447ca93f7bc946817c05e538a3132
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -186,6 +186,11 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         }
     }
 
+    public virtual bool CanAttackFar()
+    {
+        return AttackFarBehavior.canAttack;
+    }
+
     #endregion
 
     protected virtual IEnumerator Attacking()
@@ -212,7 +217,7 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
     void FacePlayer()
     {
         //Player behind enemy
-        if (!enemyController.raycast.playerDetectFront)
+        if (enemyController.raycast.playerDetectBack)
         {
             movement.ManualFlip(!movement.isFacingRight);
         }
@@ -356,7 +361,7 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
 
         //Base_EnemyAnimator checks for isAlive to play Death animation
         isAlive = false;
-        enemyStageManager.UpdateEnemyCount();
+        if(enemyStageManager != null) enemyStageManager.UpdateEnemyCount();
 
         //Disable sprite renderer before deleting gameobject
         sr.enabled = false;

--- a/_Enemy Scripts/Base_EnemyController.cs
+++ b/_Enemy Scripts/Base_EnemyController.cs
@@ -67,7 +67,9 @@ public class Base_EnemyController : MonoBehaviour
 
     void PlayerToRightCheck()
     {
-        combat.playerToRight = raycast.playerToRight;
+        //Only update if the player is actively being detected
+        if(raycast.playerDetectFront || raycast.playerDetectBack)
+            combat.playerToRight = raycast.playerToRight;
     }
 
     void AttackCheckClose()
@@ -79,7 +81,7 @@ public class Base_EnemyController : MonoBehaviour
     void AttackCheckFar()
     {
         if (!PlatformCheck() && !isRangedAttack) return;
-        if (raycast.playerInRangeFar) combat.AttackFar();
+        if (raycast.playerInRangeFar && combat.CanAttackFar()) combat.AttackFar();
     }
 
     bool PlatformCheck()

--- a/_Enemy Scripts/Enemy Behaviors/Ranged_Horizontal.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Ranged_Horizontal.cs
@@ -9,6 +9,7 @@ public class Ranged_Horizontal : Base_CombatBehavior
     [Header("Ranged Projectile")]
     [SerializeField] GameObject projectile;
     [SerializeField] Transform attackPoint;
+    //Set Projectile Damage and Speed from here, projectile prefab is set at instantiation
     [SerializeField] public float damage = 4;
     [SerializeField] public float speed = 3; //default 3
     [SerializeField] public bool canFire;
@@ -39,6 +40,7 @@ public class Ranged_Horizontal : Base_CombatBehavior
 
         yield return new WaitForSeconds(animDelay); //Charge up anim
 
+        //Instantiate projectile, set variables from this script
         GameObject projectileObj = Instantiate(projectile, attackPoint.position, transform.rotation);
         ProjectileController script = projectileObj.GetComponent<ProjectileController>();
         script.damage = damage;

--- a/_Enemy Scripts/OrbController.cs
+++ b/_Enemy Scripts/OrbController.cs
@@ -33,8 +33,8 @@ public class OrbController : MonoBehaviour
 
     private void Awake()
     {
-        rb = gameObject.GetComponent<Rigidbody2D>();
-        collider = gameObject.GetComponent<CircleCollider2D>();
+        rb = GetComponent<Rigidbody2D>();
+        collider = GetComponent<CircleCollider2D>();
         findPlayer = false;
         timeSpentFlying = 0;
 

--- a/_Enemy Scripts/Tier 2 Enemies/Shielder_EnemyCombat.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Shielder_EnemyCombat.cs
@@ -83,7 +83,7 @@ public class Shielder_EnemyCombat : Base_EnemyCombat
         InstantiateManager.Instance.XPOrbs.SpawnOrbs(transform.position, totalXPOrbs);
 
         //Base_EnemyAnimator checks for isAlive to play Death animation
-        enemyStageManager.UpdateEnemyCount();
+        if(enemyStageManager != null) enemyStageManager.UpdateEnemyCount();
         //sr.enabled = false;
         Invoke("DeleteObj", 1f); //Wait for fade out to finish
     }

--- a/_Level Generator/Additional Scripts.meta
+++ b/_Level Generator/Additional Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 96a3908815bedb244a0e2b0d8c4af445
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Level Generator/Additional Scripts/RoomDoorGenerator.cs
+++ b/_Level Generator/Additional Scripts/RoomDoorGenerator.cs
@@ -1,0 +1,82 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RoomDoorGenerator : MonoBehaviour
+{
+    [Header("References")]
+    private LevelBuilder Builder;
+    [SerializeField] GameObject BossRoomOrigin;
+    [SerializeField] List<Transform> borderingDoors;
+
+    [SerializeField] GameObject BossDoorProps;
+
+    private void Start()
+    {
+        borderingDoors = new List<Transform>();
+        if (Builder == null) Builder = GetComponentInParent<LevelBuilder>();
+    }
+
+    // void Update()
+    // {
+    //     if(Input.GetKeyDown(KeyCode.O))
+    //     {
+    //         AddBorderingDoors();
+    //     }
+    // }
+
+    public void AddBorderingDoors()
+    {
+        Invoke("GetBorderingDoors", .1f);
+    }
+
+    public void GetBorderingDoors() //Call in RoomGenerator after Walls are already added
+    {
+        borderingDoors = new List<Transform>();
+        // borderingDoors.Clear();
+
+        BossRoomOrigin = Builder.GeneratedOrigins[Builder.GeneratedOrigins.Length - 1];
+
+        DoorManager bossDoors = BossRoomOrigin.GetComponent<DoorManager>();
+        int totalDoors = bossDoors.connectedDoors.Count;
+
+        for(int i = 0; i < totalDoors; i++)
+        {
+            borderingDoors.Add(bossDoors.connectedDoors[i].transform);
+        }
+
+        Invoke("AddBossDoor", .1f);
+        //yield return on reference != null
+    }
+
+    void AddBossDoor()
+    {
+        for(int i = 0; i < borderingDoors.Count; i++)
+        {
+            Transform currDoor = borderingDoors[i].transform;
+            //Main Door/Wall object needed to get relative position to Origin
+            Vector3 doorParentPos = currDoor.position;
+            Transform doorPos = currDoor.GetComponent<DoorController>().doorOffset;
+            
+            float xRotate = 0, zRotate = 0;
+
+            if(doorParentPos.x == transform.position.x)
+            {//Door is Above or Below, Rotate Prop X 0 or 180
+                if(doorParentPos.y < transform.position.y) xRotate = 180;//Instantiate(BossDoorProps, doorPos, Quaternion.identity, BossRoomOrigin.transform);
+                else xRotate = 0;// Instantiate(BossDoorProps, doorPos, Quaternion.identity, BossRoomOrigin.transform);
+                
+            }
+            if(doorParentPos.y == transform.position.y)
+            {//Door is Left or Right, Rotate Prop Z 90 or -90
+                if(doorParentPos.x < transform.position.x) zRotate = 90;//Instantiate(BossDoorProps, currDoorPos, Quaternion.identity, BossRoomOrigin.transform);
+                else zRotate = -90; //Instantiate(BossDoorProps, currDoorPos, Quaternion.identity, BossRoomOrigin.transform);
+            }
+            
+            Instantiate(BossDoorProps, doorPos.position,
+            Quaternion.Euler(doorPos.rotation.x + xRotate, 0, doorPos.rotation.z + zRotate),
+            BossRoomOrigin.transform);
+        }
+    }
+    
+    //TODO: repeat for Shops, Trials, ...
+}

--- a/_Level Generator/Additional Scripts/RoomDoorGenerator.cs.meta
+++ b/_Level Generator/Additional Scripts/RoomDoorGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a645c0bcf0dfad146823e5564b68dea1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Level Generator/LevelBuilder.cs
+++ b/_Level Generator/LevelBuilder.cs
@@ -28,6 +28,7 @@ public class LevelBuilder : MonoBehaviour
     [SerializeField] float xDistance = 11f;
     [SerializeField] float yDistance = 6f;
     [SerializeField] bool DEBUGGING = true;
+    [SerializeField] GameObject LevelGenBoundaries;
     [SerializeField] WallGenerator WallGen;
     [SerializeField] RoomGenerator RoomGen;
     [SerializeField] public LayerMask buildLayer; //"Builder" layer
@@ -124,6 +125,7 @@ public class LevelBuilder : MonoBehaviour
     IEnumerator GenerateOriginsCO()
     {
         Debug.Log("Generating Origins...");
+        if(LevelGenBoundaries != null) LevelGenBoundaries.SetActive(true);
         builderRunning = true;
         for (int i = 0; i < totalRooms; i++)
         {
@@ -147,6 +149,9 @@ public class LevelBuilder : MonoBehaviour
         endRoom = transform.position;
 
         builderRunning = false;
+        
+        //Disable Boundaries after Origins are built
+        if(LevelGenBoundaries != null) LevelGenBoundaries.SetActive(false);
 
         yield return new WaitForSecondsRealtime(.1f);
         Debug.Log("Origins Generated");

--- a/_Level Generator/RoomGenerator.cs
+++ b/_Level Generator/RoomGenerator.cs
@@ -9,12 +9,12 @@ public class RoomGenerator : MonoBehaviour
     public LevelBuilder Builder;
 
     [Header("Shops")]
-    public int numShops = 2;
-    [SerializeField] int totalShopDeviation = 1;
+    public int numShopsLower = 2;
+    [SerializeField] int numShopsUpper = 3;
 
     [Header("Trials")]
-    public int numTrials = 1;
-    [SerializeField] int totalTrialsDeviation = 0;
+    public int numTrialsLower = 1;
+    [SerializeField] int numTrialsUpper = 1;
 
     [Space(10)]
     [Header("--- Generator Components (*Setup) ---")]
@@ -33,6 +33,7 @@ public class RoomGenerator : MonoBehaviour
 
     public bool roomGenRunning;
     public bool roomGenDone;
+    private RoomDoorGenerator roomDoorGen;
 
     private void Start()
     {
@@ -41,6 +42,7 @@ public class RoomGenerator : MonoBehaviour
 
         availableIndexes = new List<int>();
         //shopAdded = false; //Example
+        roomDoorGen = GetComponentInChildren<RoomDoorGenerator>();
     }
 
     void Update()
@@ -77,25 +79,26 @@ public class RoomGenerator : MonoBehaviour
         CreateRoom(StartRooms[0], 0); //TODO: randomize StartRooms if multiple
         CreateRoom(BossRoom, bossRoomIndex);
 
+        
 
         //Create Shops
-        int totalShops = Random.Range(numShops, numShops + totalShopDeviation);
+        int totalShops = Random.Range(numShopsLower, numShopsUpper + 1);
         for (int i = 0; i < totalShops; i++)
         {
             int randShop = Random.Range(0, totalShops); //Pick random shop from array of variations
-            int randIndex = Random.Range(0, availableIndexes.Count);
-            CreateRoom(Shops[randShop], availableIndexes[randIndex]);
+            int randRoomIndex = Random.Range(0, availableIndexes.Count);
+            CreateRoom(Shops[randShop], availableIndexes[randRoomIndex]);
         }
 
         yield return new WaitForSecondsRealtime(.01f);
 
         //Create Trial(s)
-        int totalTrials = Random.Range(numTrials - totalTrialsDeviation, numTrials + totalTrialsDeviation);
+        int totalTrials = Random.Range(numTrialsLower, numTrialsUpper + 1);
         for (int i = 0; i < totalTrials; i++) //Reserve indexes for Trials
         {
             int randTrial = Random.Range(0, totalTrials);
-            int randIndex = Random.Range(0, availableIndexes.Count);
-            CreateRoom(Trials[randTrial], availableIndexes[randIndex]);
+            int randRoomIndex = Random.Range(0, availableIndexes.Count);
+            CreateRoom(Trials[randTrial], availableIndexes[randRoomIndex]);
         }
 
         yield return new WaitForSecondsRealtime(.01f);
@@ -104,15 +107,17 @@ public class RoomGenerator : MonoBehaviour
         //Clear out list as we go
         while (availableIndexes.Count > 0)
         {
-            int i = availableIndexes[0];
+            //int i = availableIndexes[0];
             //yield return new WaitForSecondsRealtime(.01f); //0.001
 
             int rand = Random.Range(0, Rooms.Length);
 
-            CreateRoom(Rooms[rand], i);
+            CreateRoom(Rooms[rand], availableIndexes[0]);
         }
         roomGenRunning = false;
         roomGenDone = true;
+
+        roomDoorGen.AddBorderingDoors();
 
         Debug.Log("Rooms Generated");
     }

--- a/_Level Generator/WallGenerator.cs
+++ b/_Level Generator/WallGenerator.cs
@@ -161,7 +161,6 @@ public class WallGenerator : MonoBehaviour
             if(direction == 0 || direction == 2) GenerateDoor(newPos, false);
             else GenerateDoor(newPos, true);
         }
-        
     }
 
     void GenerateDoor(Vector3 newPos, bool isVertical)

--- a/_Level_Scene_Load/DoorController.cs
+++ b/_Level_Scene_Load/DoorController.cs
@@ -11,6 +11,7 @@ public class DoorController : MonoBehaviour
 
     [Header("References & Setup")]
     [SerializeField] Collider2D doorCollider;
+    public Transform doorOffset; //For use with door props
     [SerializeField] Animator animator;
     [SerializeField] string[] animNames = { "Door_Closed", "Door_Opening", "Door_Opened" };
     [SerializeField] GameObject doorArrow; //TODO: replace with arrow
@@ -25,6 +26,7 @@ public class DoorController : MonoBehaviour
         if (doorCollider == null) doorCollider = GetComponent<Collider2D>();
         if (horizontal && groundCollider == null) groundCollider = gameObject.transform.Find("Ground Platform").GetComponent<BoxCollider2D>();
         //blockDropThroughCollider
+        if(doorCollider != null) doorOffset = doorCollider.transform;
         ToggleOpenIndicator(false);
     }
     
@@ -49,6 +51,8 @@ public class DoorController : MonoBehaviour
         // if(groundCollider != null) groundCollider.tag = "OneWayPlatform";
         doorCollider.isTrigger = true;
         if(blockDropThroughCollider != null) blockDropThroughCollider.enabled = false;
+
+        ToggleOpenIndicator(true);
         //Override canDropThrough in case player is on the platform when it changes
         //if(horizontal) GameManager.Instance.PlayerMovement.canDropThrough = true;
     }
@@ -58,12 +62,12 @@ public class DoorController : MonoBehaviour
         // if(groundCollider != null) groundCollider.tag = "SolidPlatform";
         doorCollider.isTrigger = false;
         if(blockDropThroughCollider != null) blockDropThroughCollider.enabled = true;
+        ToggleOpenIndicator(false);
     }
 
     void ToggleOpenIndicator(bool toggle)
     {
-        if (doorArrow != null)
-            doorArrow.SetActive(toggle);
+        if (doorArrow != null) doorArrow.SetActive(toggle);
     }
 
     private void PlayAnim(int index)

--- a/_Level_Scene_Load/DoorManager.cs
+++ b/_Level_Scene_Load/DoorManager.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class DoorManager : MonoBehaviour
 {
     //Controls doors in Stages
-    [SerializeField] List<DoorController> connectedDoors;
+    [SerializeField] public List<DoorController> connectedDoors;
     private bool checkForDoors;
     public RoomClear roomClear;
 

--- a/_Manager Handler Scripts/PlayerItemsManager.cs
+++ b/_Manager Handler Scripts/PlayerItemsManager.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerItemsManager : MonoBehaviour
+{
+    [SerializeField] GameObject[] ItemList;
+    
+    
+    
+    void Start()
+    {
+        
+    }
+
+    public void RefreshStatItems()
+    {
+        //Refresh items with stat boosting effects
+        //Player gets boost of total stats from items 
+            //(Player.MaxHealth += items.boostedHealth)
+
+        
+    }
+}

--- a/_Manager Handler Scripts/PlayerItemsManager.cs.meta
+++ b/_Manager Handler Scripts/PlayerItemsManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62fff76c613c3a540af90392c5d1f9e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Manager Handler Scripts/Room Managers/PlayerDoorController.cs
+++ b/_Manager Handler Scripts/Room Managers/PlayerDoorController.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerDoorController : MonoBehaviour
+{
+    //When player enters a new room entrance, move the player out of the doorway into the room
+    
+    [Header("References")]
+    [SerializeField] DoorController doorController;
+    [SerializeField] Transform teleportEndpoint;
+
+    void Start()
+    {
+        if(doorController == null) doorController = GetComponentInParent<DoorController>();
+        if(teleportEndpoint == null) teleportEndpoint = transform.GetChild(0).transform;
+    }
+
+    void OnTriggerEnter2D(Collider2D collision)
+    {
+        //When player enters trigger, reposition to the teleportEndpoint in the next room
+        if(!doorController.isOpen) return;
+        if(collision.CompareTag("Player"))
+        {
+            GameManager.Instance.Player.position = teleportEndpoint.position;
+        }
+    }
+}

--- a/_Manager Handler Scripts/Room Managers/PlayerDoorController.cs.meta
+++ b/_Manager Handler Scripts/Room Managers/PlayerDoorController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aff62e0a5c956ef40935d0e4a44f2ee2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Manager Handler Scripts/Room Managers/RoomClear.cs
+++ b/_Manager Handler Scripts/Room Managers/RoomClear.cs
@@ -5,7 +5,8 @@ using UnityEngine;
 public class RoomClear : MonoBehaviour
 {
     public bool roomCleared; //for reference from Item Selection
-    public bool neutralRoom = false;
+    public bool neutralRoom = false; //If true, room stays cleared
+    //^ Use for Start room, Shops, etc
 
     [Header("References")]
     public DoorManager DoorManager;
@@ -13,6 +14,7 @@ public class RoomClear : MonoBehaviour
     void Start()
     {
         roomCleared = false;
+
         if (DoorManager == null) DoorManager = GetComponent<DoorManager>();
         //if (DoorManager == null) DoorManager = GameObject.FindGameObjectWithTag("DoorManager").GetComponent<DoorManager>();
             //This only gets the number of children under "Enemies", doesn't count children's children

--- a/_Manager Handler Scripts/VFXManager.cs
+++ b/_Manager Handler Scripts/VFXManager.cs
@@ -1,62 +1,52 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class VFXManager : MonoBehaviour
 {
-    [SerializeField] private GameObject RunVFX;
-    [SerializeField] private GameObject LandingVFX; //reusing for Jump
-    [SerializeField] private GameObject JumpVFX; //^
-    [SerializeField] private GameObject DashVFX;
-    [SerializeField] private GameObject StopVFX;
+    [SerializeField] private VFXHandler RunVFX;
+    [SerializeField] private VFXHandler JumpVFX;
+    [SerializeField] private VFXHandler DashVFX;
+    [SerializeField] private VFXHandler StopVFX;
 
-    float jumpVFXDuration = .417f;
-    float runVFXDuration = .417f;
-    float dashVFXDuration = .5f;
-    float stopVFXDuration = .417f;
+    // float jumpVFXDuration = .417f;
+    // float runVFXDuration = .417f;
+    // float dashVFXDuration = .5f;
+    // float stopVFXDuration = .417f;
 
-
-    public void RunFX(Transform spawnPos, bool facingRight = true)
+    public void RunFX(Transform spawnTransform, bool facingRight = true)
     {
         //Needs to spawn in the direction the player is facing.
         //P -> Spawn normal, <- P Spawn Flipped
         if (RunVFX == null) return;
-        GameObject g;
-        if(facingRight) g = Instantiate(RunVFX, spawnPos.position, Quaternion.identity, transform);
-        else g = Instantiate(RunVFX, spawnPos.position, spawnPos.rotation * Quaternion.Euler(0, 180f, 0), transform);
 
-        StartCoroutine(DeleteObject(g, runVFXDuration));
+        if (facingRight) RunVFX.ShowEffect(spawnTransform.position, 0);
+        else RunVFX.ShowEffect(spawnTransform.position, 180);
     }
 
-    public void JumpFX(Transform spawnPos)
+    public void JumpFX(Transform spawnTransform)
     {
         if (JumpVFX == null) return;
-        GameObject g = Instantiate(JumpVFX, spawnPos.position, Quaternion.identity, transform);
-        StartCoroutine(DeleteObject(g, jumpVFXDuration));
+        JumpVFX.ShowEffect(spawnTransform.position);
     }
 
-    public void StopFX(Transform spawnPos, bool facingRight = true)
+    public void StopFX(Transform spawnTransform, bool facingRight = true)
     {
         //Needs to spawn in the direction the player is facing.
         //P -> Spawn normal, <- P Spawn Flipped
         if(StopVFX == null) return;
-        GameObject g;
-        if(facingRight) g = Instantiate(StopVFX, spawnPos.position, Quaternion.identity, transform);
-        else g = Instantiate(StopVFX, spawnPos.position, spawnPos.rotation * Quaternion.Euler(0, 180f, 0), transform);
 
-        StartCoroutine(DeleteObject(g, stopVFXDuration));
+        if (facingRight) StopVFX.ShowEffect(spawnTransform.position, 0);
+        else StopVFX.ShowEffect(spawnTransform.position, 180);
     }
 
-    public void DashFX(Transform spawnPos, bool facingRight = true)
+    public void DashFX(Transform spawnTransform, bool facingRight = true)
     {
         //Needs to spawn in the direction the player is facing.
         //P -> Spawn normal, <- P Spawn Flipped
         if (DashVFX == null) return;
-        GameObject g;
-        if (facingRight) g = Instantiate(DashVFX, spawnPos.position, Quaternion.identity, transform);
-        else g = Instantiate(DashVFX, spawnPos.position, spawnPos.rotation * Quaternion.Euler(0, 180f, 0), transform);
 
-        StartCoroutine(DeleteObject(g, dashVFXDuration));
+        if (facingRight) DashVFX.ShowEffect(spawnTransform.position, 0);
+        else DashVFX.ShowEffect(spawnTransform.position, 180);
     }
 
     IEnumerator DeleteObject(GameObject g, float duration)


### PR DESCRIPTION
### Level Generation
- Created Vertical/Horizontal Wall and Door Prefabs
- Level generation is setup and working
- Added Door triggers to update the Player location
- Enemies are now stored in room prefabs

### Rooms
- Origin objects manage rooms and their connecting doors
  - Doors are managed by both connecting rooms
- Doors are closed when the Player enters if the room hasn't been
cleared
- Added a dividing collider in Doors
- Player is teleported to the corresponding transform attached to the
trigger
- This prevents issues with the Player getting stuck in the door
collider as it closed
- Added door location variations
  - Vertical Doors: Top, Middle, Bottom
  - Horizontal Doors: Left, Middle, Right
- Added Arrow indicators for when doors are open
- Added Props to attach to the Boss room's connecting doors
- Added 6 Shops (not functional yet)
- Neutral rooms have no door open requirement and will always have open
doors
- Added 10 total Rooms with Enemy setups
- Added a somewhat functional wave spawner (only works with 2 waves)
  - Enemies are spawned by quantity
    - When cleared, the remaining enemies are spawned

### Camera
- Now moves to the room the Player is in
- Removed previous damping effect

### Player
- Added pooling for VFX
- Added Jump input buffering
- Player jump is no longer reset when entering a ground collider, script
now checks if velocity reaches 0 before resetting

### Enemies
- Updated Shielder enemy behavior
  - Increased cooldown time on long range attack
- When long range attack is on cooldown, Shielder will switch to its
Chase state and try to Melee the player
    - Increased Raycast range for player detection 
- Fixed issues with Flip being called when no longer detecting the Player

### Misc
- Added an Animation timing calculator tool, found under Tools tab