### PR TITLE
Boss Phases, ChargeUp Buff

### DIFF
--- a/CastExplosion.cs
+++ b/CastExplosion.cs
@@ -75,7 +75,6 @@ public class CastExplosion : MonoBehaviour
         // Toggle objects are Disabled, otherwise Destroy
         if (TOGGLE) gameObject.SetActive(false);
         else if (!POOLED) Destroy(gameObject);
-        // else Destroy(gameObject);
     }
 
     void CheckHit()

--- a/CastExplosion.cs
+++ b/CastExplosion.cs
@@ -29,6 +29,7 @@ public class CastExplosion : MonoBehaviour
 
     [Header("=== TOGGLE Prefab ===")]
     [SerializeField] bool TOGGLE = false;
+    [SerializeField] bool POOLED = false;
 
     [Space(10)]
     [Header("Damage Variables")]
@@ -47,12 +48,13 @@ public class CastExplosion : MonoBehaviour
     void Start()
     {
         //! - Make sure animations are default set to a blank frame anim in animation controller
-        if (!TOGGLE) StartCoroutine(PlayAnims());
+        // if (!TOGGLE) StartCoroutine(PlayAnims());
     }
 
     void OnEnable()
     {
-        if (TOGGLE) StartCoroutine(PlayAnims());
+        // if (TOGGLE) StartCoroutine(PlayAnims());
+        StartCoroutine(PlayAnims());
     }
 
     IEnumerator PlayAnims()
@@ -72,7 +74,8 @@ public class CastExplosion : MonoBehaviour
         
         // Toggle objects are Disabled, otherwise Destroy
         if (TOGGLE) gameObject.SetActive(false);
-        else Destroy(gameObject);
+        else if (!POOLED) Destroy(gameObject);
+        // else Destroy(gameObject);
     }
 
     void CheckHit()

--- a/ColossalBoss_EnemyCombat.cs
+++ b/ColossalBoss_EnemyCombat.cs
@@ -17,15 +17,15 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
     [SerializeField] Transform bossGroundOffset;
 
     [Header("= Colossal Boss = : (1) Melee/Explosion")]
-    [SerializeField] GameObject MeleeExplosionPrefab;
-    [SerializeField] GameObject MeleePrefab;
+    [SerializeField] GameObject MeleePrefab; //Toggled GameObject
+    [SerializeField] PrefabHandler ExplosionHandler;
     [SerializeField] float explosionCastDelay = .2f;
 
     [Header("= Colossal Boss = : (2) SuperAttack")]
     [SerializeField] GameObject SuperAttackExplosionPrefab;
 
     [Header("= Colossal Boss = : (3) Spin")]
-    [SerializeField] GameObject BoomerangArms;
+    [SerializeField] GameObject BoomerangArms; //Toggled GameObject
 
     [Header("= Colossal Boss = : (4) ChargeUp")]
     [SerializeField] private bool canFly;
@@ -295,24 +295,44 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
 
 //Prefab: Pass in number of explosions to spawn, 
 //  change trackPlayer to Instantiate at Player or in a line after the previous position
-    IEnumerator MeleeExplosionOnly(int iterations, bool trackPlayer = false)
+    IEnumerator MeleeExplosionOnly(int iterations, bool trackPlayer = false, bool multiple = false)
     {
         if(iterations <= 0) yield return null;
         Vector3 castPos;
         //Spawn multiple explosions in a wave
         for(int i=0; i<iterations; i++)
         {
+            if(!isAlive) break;
             if(!trackPlayer)
             {
-                if(!isAlive) break;
                 castPos = GetOwnPosX();
                 if(movement.isFacingRight) castPos.x += i;
                 else castPos.x -= i;
-                Instantiate(MeleeExplosionPrefab, castPos, Quaternion.identity);
             }
             else
             {
-                Instantiate(MeleeExplosionPrefab, GetPlayerPosX(), Quaternion.identity);
+                castPos = GetPlayerPosX();
+            }
+
+            ExplosionHandler.SpawnPrefab(castPos);
+            // Instantiate(MeleeExplosionPrefab, castPos, Quaternion.identity);
+            if(multiple)
+            {
+                yield return new WaitForSeconds(.2f);
+                Vector3 castPos1 = new Vector3(castPos.x+1, castPos.y, 0);
+                ExplosionHandler.SpawnPrefab(castPos1);
+                // Instantiate(MeleeExplosionPrefab, castPos1, Quaternion.identity);
+                Vector3 castPos2 = new Vector3(castPos.x-1, castPos.y, 0);
+                ExplosionHandler.SpawnPrefab(castPos2);
+                // Instantiate(MeleeExplosionPrefab, castPos2, Quaternion.identity);
+
+                yield return new WaitForSeconds(.2f);
+                Vector3 castPos3 = new Vector3(castPos.x+2, castPos.y, 0);
+                ExplosionHandler.SpawnPrefab(castPos3);
+                // Instantiate(MeleeExplosionPrefab, castPos3, Quaternion.identity);
+                Vector3 castPos4 = new Vector3(castPos.x-2, castPos.y, 0);
+                ExplosionHandler.SpawnPrefab(castPos4);
+                // Instantiate(MeleeExplosionPrefab, castPos4, Quaternion.identity);
             }
 
             yield return new WaitForSeconds(explosionCastDelay);
@@ -439,7 +459,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
             animator.PlayManualAnim(6, fullAttackAnimTime[4]);
             yield return new WaitForSeconds(attackDelayTime[4]);
             movement.ToggleFlip(false);
-            StartCoroutine(MeleeExplosionOnly(1, true));
+            StartCoroutine(MeleeExplosionOnly(1, true, true));
             yield return new WaitForSeconds((fullAttackAnimTime[4] - attackDelayTime[4])+.1f);
             movement.ToggleFlip(true);
         }

--- a/ObjectPoolers/PrefabHandler.cs
+++ b/ObjectPoolers/PrefabHandler.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+public class PrefabHandler : MonoBehaviour
+{
+    // Enables objects stored in pools
+    // ObjectPoolerList will enable objects if available
+    //  otherwise Instantiates a new object
+    [Header("Pooled Objects")]
+    [SerializeField]
+    private ObjectPoolerList PrefabPool;
+
+    private void Start()
+    {
+        if (PrefabPool == null) PrefabPool = GetComponent<ObjectPoolerList>();
+    }
+
+    public void SpawnPrefab(Vector3 pos)
+    {
+        GameObject prefab = PrefabPool.GetObject();
+        prefab.transform.position = pos;
+        prefab.transform.rotation = Quaternion.identity;
+        prefab.SetActive(true);
+    }
+
+    public void SpawnPrefab(Vector3 pos, float yRotation)
+    {
+        GameObject prefab = PrefabPool.GetObject();
+        prefab.transform.position = pos;
+        prefab.transform.rotation = Quaternion.Euler(0, yRotation, 0);
+        prefab.SetActive(true);
+    }
+}

--- a/ObjectPoolers/PrefabHandler.cs.meta
+++ b/ObjectPoolers/PrefabHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c84bcd7d9f833714586750dab7a3d6b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ObjectPoolers/PrefabPoolerHelper.cs
+++ b/ObjectPoolers/PrefabPoolerHelper.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PrefabPoolerHelper : MonoBehaviour
+{
+    //! - Attached to a Prefab, will move to back to the pool once the object is disabled
+    //Object Disable needs to be handled in the Prefab's script
+    [Header("References")]
+    [SerializeField] ObjectPoolerList pool;
+    [SerializeField] float poolDelay = 1f;
+
+    private void Start()
+    {
+        pool = GetComponentInParent<ObjectPoolerList>();
+        if(pool != null) pool.ReturnObject(gameObject);
+        Debug.Log("Getting pool list...");
+    }
+
+    private void OnEnable()
+    {
+        // if(pool == null) pool = GetComponentInParent<ObjectPoolerList>();
+        StartCoroutine(PoolObject(poolDelay));
+    }
+
+    private void OnDisable()
+    {
+        // if(pool != null) pool.ReturnObject(gameObject);
+    }
+
+    IEnumerator PoolObject(float duration)
+    {
+        if(pool == null) pool = GetComponentInParent<ObjectPoolerList>();
+        yield return new WaitForSeconds(duration);
+        pool.ReturnObject(gameObject);
+    }
+}

--- a/ObjectPoolers/PrefabPoolerHelper.cs
+++ b/ObjectPoolers/PrefabPoolerHelper.cs
@@ -14,12 +14,10 @@ public class PrefabPoolerHelper : MonoBehaviour
     {
         pool = GetComponentInParent<ObjectPoolerList>();
         if(pool != null) pool.ReturnObject(gameObject);
-        Debug.Log("Getting pool list...");
     }
 
     private void OnEnable()
     {
-        // if(pool == null) pool = GetComponentInParent<ObjectPoolerList>();
         StartCoroutine(PoolObject(poolDelay));
     }
 

--- a/ObjectPoolers/PrefabPoolerHelper.cs.meta
+++ b/ObjectPoolers/PrefabPoolerHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 169d4a799b6e504419b09a061f324b6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Animators/KillEffectsAnimator.cs
+++ b/_Animators/KillEffectsAnimator.cs
@@ -7,6 +7,7 @@ public class KillEffectsAnimator : MonoBehaviour
     [SerializeField] Animator animator;
     [SerializeField] string animationName;
     [SerializeField] float animationTime;
+    [SerializeField] bool TOGGLE = false;
 
     private void OnEnable()
     {
@@ -16,6 +17,7 @@ public class KillEffectsAnimator : MonoBehaviour
 
     private void DeleteObj()
     {
-        Destroy(gameObject);
+        if(TOGGLE) gameObject.SetActive(false);
+        else Destroy(gameObject);
     }
 }

--- a/_Animators/ToggleEffectAnimator.cs
+++ b/_Animators/ToggleEffectAnimator.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ToggleEffectAnimator : MonoBehaviour
+{
+    [Header("Setup")]
+    [SerializeField] Animator anim;
+    [SerializeField] int[] HashedAnimName;
+    [SerializeField] float[] ChargeAnimTimes;
+    [SerializeField] float[] FullAnimTimes;
+
+    void Awake()
+    {
+        if (anim == null) GetComponent<Animator>();
+    }
+
+    public void PlayAnim(int index)
+    {
+        anim.Play(HashedAnimName[index]);
+    }
+
+    public float GetChargeTime(int index)
+    {
+        return ChargeAnimTimes[index];
+    }
+
+    public float GetAnimTime(int index)
+    {
+        return FullAnimTimes[index];
+    }
+}

--- a/_Animators/ToggleEffectAnimator.cs.meta
+++ b/_Animators/ToggleEffectAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df16a4d7fc53a1e4792e51dfba9de292
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Enemy Scripts/Base_BossAnimator.cs
+++ b/_Enemy Scripts/Base_BossAnimator.cs
@@ -129,7 +129,7 @@ public class Base_BossAnimator : MonoBehaviour
     {
         if (Time.time < lockedTill) return currentState;
 
-        if (!combat.isAlive) return Death;
+        if (combat.playDeathAnim) return Death;
         //if (movement.isJumping) return Jump;
 
         //if (movement.isGrounded)

--- a/_Enemy Scripts/Base_BossCombat.cs
+++ b/_Enemy Scripts/Base_BossCombat.cs
@@ -5,13 +5,13 @@ using UnityEngine;
 public class Base_BossCombat : MonoBehaviour, IDamageable
 {
 
-    [Header("Attack Behavior Setup")]
+    [Header("=== Attack Behavior Setup ===")]
     [SerializeField] public Base_CombatBehavior AttackCloseBehavior;
     [SerializeField] public Base_CombatBehavior AttackFarBehavior;
     public bool canAttackFar;
     public bool canAttack;
 
-    [Header("References/Setup")]
+    [Header("=== References/Setup ===")]
     public LayerMask playerLayer;
     [SerializeField] protected Transform[] attackPoint;
     public float[] attackRangeX;
@@ -26,18 +26,19 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
     [Space(10)]
     [SerializeField] public bool DEBUGMODE = false;
     [SerializeField] protected float spawnFXScale = 2.5f; //2.5f default 
-    [Header("*Animation Times")]
+    [Header("=== *Animation Times ===")]
     [SerializeField] protected float[] fullAttackAnimTime; //1f, 1.416667f
     [SerializeField] protected float[] attackDelayTime; //0.0834f, 0.834f
 
     [Space(10)]
 
-    [Header("Start() Reference Initialization")]
+    [Header("=== Start() Reference Initialization ===")]
     public Base_BossMovement movement;
     public Base_BossAnimator animator;
     [SerializeField] protected SpriteRenderer sr;
     [SerializeField] protected HealthBar healthBar;
     [SerializeField] protected EnemyStageManager enemyStageManager;
+    [SerializeField] protected float spawnDelay = 1f;
 
     [Space(10)]
 
@@ -70,6 +71,7 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
     [Header("--- Status ---")]
     //Bools
     [SerializeField] public bool isAlive;
+    [SerializeField] public bool playDeathAnim;
     [SerializeField] public bool isSpawning;
     [SerializeField] public int currentPhase;
     protected int numAttacks;
@@ -78,8 +80,7 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
     public bool playerToRight;
     Coroutine StunnedCO;
     protected Coroutine AttackingCO;
-    private bool initialEnable;
-    [Header("Attack Logic variables")]
+    [Header("--- Attack Logic variables ---")]
     public bool attackClose;
     public bool attackMain;
     public bool playerInFront;
@@ -91,7 +92,6 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
 
     protected virtual void Awake()
     {
-        initialEnable = true;
         sr = GetComponentInChildren<SpriteRenderer>();
         mDefault = sr.material;
         animator = GetComponentInChildren<Base_BossAnimator>();
@@ -112,11 +112,13 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
 
         currentHP = maxHP;
         isAlive = true;
+        playDeathAnim = false;
         isStunned = false;
         if (healthBar == null) healthBar = GetComponentInChildren<HealthBar>();
         if (healthBar != null)
         {
             healthBar.SetHealth(maxHP);
+            healthBar.gameObject.SetActive(false);
         }
 
         //Defaults
@@ -148,15 +150,12 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
     {
         //Manual set, duration of SpawnIndicator SpawnIn
         //Toggle enemy before spawning in
-        if(initialEnable) return;
-        float spawnDelay = .5f;
-        animator.PlayManualAnim(5, spawnDelay);
         StartCoroutine(SpawnCO(spawnDelay));
     }
 
     protected virtual void OnDisable()
     { 
-        initialEnable = false; 
+        
     }
 
     // Update is called once per frame
@@ -320,7 +319,7 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         isStunned = false;
     }
 
-    void StopAttack(bool toggleFlip = false)
+    protected void StopAttack(bool toggleFlip = false)
     {
         if (AttackingCO != null) StopCoroutine(AttackingCO);
         isAttacking = false;
@@ -381,6 +380,7 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
 
         //Base_EnemyAnimator checks for isAlive to play Death animation
         isAlive = false;
+        playDeathAnim = true;
         if(enemyStageManager != null) enemyStageManager.UpdateEnemyCount();
 
         //Disable sprite renderer before deleting gameobject

--- a/_Enemy Scripts/Base_BossController.cs
+++ b/_Enemy Scripts/Base_BossController.cs
@@ -39,7 +39,6 @@ public class Base_BossController : MonoBehaviour
         ChasePlayer();
         PlayerToRightCheck();
 
-        // if (!combat.canAttack) return;
         // LedgeWallCheck();
         AttackCheck();
     }
@@ -58,8 +57,6 @@ public class Base_BossController : MonoBehaviour
 
     protected virtual void AttackCheck()
     {
-        combat.Attack();
-
         //These variables determine lunge distance and direction during attacks
         combat.playerInFront = playerDetect.playerDetectFront;
         combat.attackClose = playerDetect.PlayerDistTooClose();
@@ -67,8 +64,9 @@ public class Base_BossController : MonoBehaviour
         combat.backToWall = playerDetect.wallDetectBack; //Wall detect only checks behind boss
         combat.faceToWall = playerDetect.wallDetectFront;
 
-        // if(!combat.isAttacking) return;
         combat.distanceToPlayer = PlayerDistCheck();
+
+        combat.Attack();
     }
 
     protected virtual void ChasePlayer()

--- a/_Level_Scene_Load/EnemyStageManager.cs
+++ b/_Level_Scene_Load/EnemyStageManager.cs
@@ -52,7 +52,7 @@ public class EnemyStageManager : MonoBehaviour
     {
         for(int i = 0; i < transform.childCount; i++)
         {
-            if(transform.GetChild(i).CompareTag("Enemy"))
+            if(transform.GetChild(i).CompareTag("Enemy") || transform.GetChild(i).CompareTag("Boss"))
             {
                 //Only need the one Enemy parent object, break when found
                 enemyParentObj = transform.GetChild(i).transform;
@@ -65,7 +65,11 @@ public class EnemyStageManager : MonoBehaviour
         if(enemyCount > 0)
         {
             for(int i = 0; i < enemyCount; i++)
-                enemyParentObj.GetChild(i).gameObject.SetActive(false);
+            {
+                var enemyObj = enemyParentObj.GetChild(i).gameObject;
+                enemyObj.SetActive(false);
+                // if(enemyObj.CompareTag("Enemy")) enemyObj.SetActive(false);
+            }
         }
     }
 


### PR DESCRIPTION
### Boss Updates
- Boss ChargeUp Attack(s) now spawn 5 total explosions expanding from the center
- Added pooling for the explosions with the PrefabPoolerHelper and PrefabHandler scripts
  - This is more flexible than the other pooler scripts
- Boss Phases
  - When taking Damage, the Boss will check if its health has reached the threshold for the next phase
  - When reaching the next phase, it will increase defenses with a Shield and play a short animation before reducing defenses and attacking again

### Bug Fixes
- Fixed Boss not Sleeping on spawn
- Fixed Boss floating in air if killed during float
  - Rigidbody and collider physics were being disabled on Death, added a short delay to allow the Boss to fall to the ground first
- Fixed collisions issues with some Room Platforms and Doors
- Fixed Sprite Layering issues
  - Updated Sprite layers for Walls, Platforms and Doors
  - Walls and Doors are now on a new layer in front of the Ground layer