### PR TITLE
Augment update

### DIFF
--- a/ShopController.cs
+++ b/ShopController.cs
@@ -7,10 +7,15 @@ public class ShopController : MonoBehaviour
     [SerializeField] GameObject interactPrompt;
     [SerializeField] GameObject inputPrompt;
     [SerializeField] GameObject shopWindow;
+    public AugmentPool augmentPool;
     private bool canTakeInput;
+    public bool oneTimePurchaseDone;
 
     void Start()
     {
+        //augmentPool reference for cross-scene ref
+        if(augmentPool == null) augmentPool = GameManager.Instance.AugmentPool;
+        oneTimePurchaseDone = false;
         ToggleText(false);
         canTakeInput = false;
         OpenShop(false);
@@ -20,7 +25,8 @@ public class ShopController : MonoBehaviour
     {
         if(!canTakeInput) return;
         //Checks if game is already paused, or input is disabled
-        if(!GameManager.Instance.inputAllowed) return; 
+        if(!GameManager.Instance.inputAllowed) return;
+        if(oneTimePurchaseDone) return;
 
         if(Input.GetButtonDown("Interact"))
         {
@@ -49,6 +55,7 @@ public class ShopController : MonoBehaviour
 
     void OnTriggerEnter2D(Collider2D collider)
     {
+        if(oneTimePurchaseDone) return;
         if(!collider.CompareTag("Player")) return;
         ToggleText(true);
         canTakeInput = true;

--- a/_Augments/Augment.cs
+++ b/_Augments/Augment.cs
@@ -25,9 +25,9 @@ public class Augment : ScriptableObject
     public enum _BuffedStat { 
         Health, Defense, MoveSpeed, 
         AttackDamage, AttackSpeed, 
-        CritChance, CritMultiplier};
+        CritChance, CritMultiplier };
     public _BuffedStat BuffedStat;
-    //TODO: figure out how to buff the specified player stat
+    //TODO: figure out how to buff the specified player stat//needs testing, might work
     
     [Header("= Debuffed Stats =")]
     public float StatDecrease;

--- a/_Augments/Inventory.cs
+++ b/_Augments/Inventory.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 
 public class Inventory : MonoBehaviour
 {
-    public int goldAmount;
+    public int goldAmount; //XPAmount
 
     [Header("References")]
     [SerializeField] TextMeshProUGUI goldCount;
@@ -16,7 +16,7 @@ public class Inventory : MonoBehaviour
         if (goldCount != null) UpdateGold();
     }
 
-    public void GiveGold(int amount)
+    public void UpdateGold(int amount)
     {
         goldAmount += amount;
         if (goldCount != null) UpdateGold();

--- a/_Enemy Scripts/OrbController.cs
+++ b/_Enemy Scripts/OrbController.cs
@@ -90,7 +90,7 @@ public class OrbController : MonoBehaviour
         //Check to make sure hits aren't registered multiple times on collision
         if (hitDone) return;
         hitDone = true;
-        inventory.GiveGold(1);
+        inventory.UpdateGold(1); //GiveXP
         animator.Play("PuffOfSmoke");
 
         Invoke("DestroyObject", 0.67f); //Delay to play animation

--- a/_Manager Handler Scripts/GameManager.cs
+++ b/_Manager Handler Scripts/GameManager.cs
@@ -6,6 +6,7 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
 
+    public bool inputAllowed;
     public PauseMenu Pause;
     public Transform Player;
 
@@ -15,7 +16,7 @@ public class GameManager : MonoBehaviour
     public AugmentInventory AugmentInventory;
     public Inventory Inventory;
     public int PlayerCurrPlatform;
-    public bool inputAllowed;
+    public AugmentPool AugmentPool;
 
     private void Awake()
     {
@@ -27,6 +28,8 @@ public class GameManager : MonoBehaviour
         PlayerCombat = Player.GetComponent<Base_PlayerCombat>();
         PlayerTargetOffset = GameObject.FindGameObjectWithTag("PlayerTargetOffset").transform;
         if (Inventory == null) Inventory = GetComponent<Inventory>();
+
+        inputAllowed = true;
     }
 
     private void Update()

--- a/_Manager Handler Scripts/GameManager.cs
+++ b/_Manager Handler Scripts/GameManager.cs
@@ -12,6 +12,7 @@ public class GameManager : MonoBehaviour
     public Base_PlayerMovement PlayerMovement;
     private Base_PlayerCombat PlayerCombat;
     public Transform PlayerTargetOffset;
+    public AugmentInventory AugmentInventory;
     public Inventory Inventory;
     public int PlayerCurrPlatform;
     public bool inputAllowed;

--- a/_Player Scripts/AugmentInventory.cs
+++ b/_Player Scripts/AugmentInventory.cs
@@ -98,13 +98,6 @@ public class AugmentInventory : MonoBehaviour
         //Reset Player stats before re-applying stat boosts
         ResetPlayerStats();
 
-
-        // for(int i=0; i<augmentManager.activeSlots; i++)
-        // {
-        //     //augmentManager.Slots[i]. ... //TODO: update player stats
-        //      PickUpAugment()
-        // }
-
         for(int i=0; i<heldAugments.Count; i++)
         {
             ApplyAugmentStats(heldAugments[i]);
@@ -115,6 +108,8 @@ public class AugmentInventory : MonoBehaviour
         //Update health
         if(combat.currentHP < tempPlayerHP) combat.currentHP = combat.maxHP;
         else combat.currentHP = tempPlayerHP;
+
+        combat.HealPlayer(0, false);
     }
 
     public void AddAugment(AugmentScript augment)
@@ -146,11 +141,6 @@ public class AugmentInventory : MonoBehaviour
             //case 5: crit chance?
             default: break;
         }
-    }
-
-    private void PickUpAugment(AugmentScript augment)
-    {
-        //TODO: might not use?, called in AugmentDisplay (since it has direct access to AugmentScript listed)
     }
 
 ////////////////

--- a/_Player Scripts/AugmentInventory.cs
+++ b/_Player Scripts/AugmentInventory.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class AugmentInventory : MonoBehaviour
 {
     [Header("References")]
-    // [SerializeField] AugmentManager augmentManager;
+    [SerializeField] AugmentInventoryDisplay augmentInventoryDisplay;
     [SerializeField] Base_PlayerCombat combat;
     [SerializeField] Base_PlayerMovement movement;
     [Header("====== BASE STATS ======")]
@@ -115,6 +115,7 @@ public class AugmentInventory : MonoBehaviour
     public void AddAugment(AugmentScript augment)
     {
         heldAugments.Add(augment);
+        if(augmentInventoryDisplay != null) augmentInventoryDisplay.AddAugmentToDisplay(heldAugments);
         UpdateAugments();
     }
 
@@ -142,26 +143,6 @@ public class AugmentInventory : MonoBehaviour
             default: break;
         }
     }
-
-////////////////
-//TODO: might just use augmentManager instead of here
-
-//     public void AddAugment(Augment aug)
-//     {
-//         //Get current Augment index
-
-//         // UI_AugmentDisplay
-//     }
-
-//     public void RemoveAugment(Augment aug)
-//     {
-
-//     }
-// //Private calls
-//     private void NewAugment()
-//     {
-        
-//     }
 
 #endregion
 

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -407,11 +407,12 @@ public class Base_PlayerCombat : MonoBehaviour
         CheckDie();
     }
 
-    public void HealPlayer(float healAmount)
+    public void HealPlayer(float healAmount, bool showNumber = true)
     {
         if (!isAlive) return;
 
-        InstantiateManager.Instance.TextPopups.ShowHeal(healAmount, textPopupOffset.position);
+        if(showNumber)
+            InstantiateManager.Instance.TextPopups.ShowHeal(healAmount, textPopupOffset.position);
 
         if (currentHP < maxHP) currentHP += healAmount;
         if (currentHP > maxHP) currentHP = maxHP;

--- a/_UI Scripts/HealthBar.cs
+++ b/_UI Scripts/HealthBar.cs
@@ -72,6 +72,6 @@ public class HealthBar : MonoBehaviour
         lerpTimer = 0f;
 
         if(healthNumbers != null)
-            healthNumbers.text = currentHealth + "/" + maxHealth;
+            healthNumbers.text = currentHealth + " / " + maxHealth;
     }
 }


### PR DESCRIPTION
### Augment Pool
- Augments are sorted into ownedAugments and unownedAugments lists
  - This separates which augments are shown to the Player in Shops
- Moved to PlayerScene, Shops will now get the reference cross-scene
- Augment Levels are randomized when pulled

### Augment Select Menu
- Added an Augment Shop/Reward Menu
  - Prices can be toggled on for Shops and off for Rewards
    - Prices are determined by the Augment's Tier and Level
    - Text will change to Red if the Player can't afford it
  - The Player can only select one before the Shop closes
  - Augments listed can be refreshed
  - Updated UI to show which Augment is being selected
  - Duplicate Augments will no longer appear

### Augment Inventory
- Replaced AugmentManager
- Acquired augments are stored in the Player Inventory
- Player stats are now updated as new Augments are added
- Held Augments are now displayed at the bottom of the screen
  - Name and Description will now display when hovering over the Augment Icon

### Misc
- Added rounding to displayed damage numbers, now displayed as whole numbers