### PR TITLE
Augment Tier Pools and Weights

### DIFF
--- a/ShopController.cs
+++ b/ShopController.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public class ShopController : MonoBehaviour
 {
+    [Header("Testing")]
+    [SerializeField] private bool DEBUGGING = false;
+    [Space(10)]
     [SerializeField] GameObject interactPrompt;
     [SerializeField] GameObject inputPrompt;
     [SerializeField] GameObject shopWindow;
@@ -26,7 +29,7 @@ public class ShopController : MonoBehaviour
         if(!canTakeInput) return;
         //Checks if game is already paused, or input is disabled
         if(!GameManager.Instance.inputAllowed) return;
-        if(oneTimePurchaseDone) return;
+        if(oneTimePurchaseDone && !DEBUGGING) return;
 
         if(Input.GetButtonDown("Interact"))
         {
@@ -55,7 +58,7 @@ public class ShopController : MonoBehaviour
 
     void OnTriggerEnter2D(Collider2D collider)
     {
-        if(oneTimePurchaseDone) return;
+        if(oneTimePurchaseDone && !DEBUGGING) return;
         if(!collider.CompareTag("Player")) return;
         ToggleText(true);
         canTakeInput = true;

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -104,7 +104,6 @@ public class AugmentDisplay : MonoBehaviour
         ToggleOverlay(false);
         DisplayName.text = augmentScript.Name;
         AugmentIcon_Image.sprite = augmentScript.Icon_Image;
-        Border_Image.sprite = augmentScript.Border_Image;
         DisplayDescription.text = augmentScript.Description;
         DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
         if(PriceDisplay != null) PriceDisplay.text = Price.ToString();

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -1,0 +1,164 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class AugmentDisplay : MonoBehaviour
+{
+    [SerializeField] public AugmentScript augmentScript;
+    [SerializeField] private AugmentSelectMenu selectMenu;
+    public bool allowInput;
+
+    [Space(10)]
+    [Header("Display Toggles")]
+    [SerializeField] GameObject selectedOverlay;
+    [SerializeField] GameObject FullDisplayParent;
+
+    [Space(10)]
+    [Header("== Needed Setup ==")]
+    [Header("Icons")]
+    [SerializeField] public Image AugmentIcon_Image;
+    [SerializeField] public Image Border_Image;
+
+    [SerializeField] public bool alwaysDisplay = false;
+    [Space(10)]
+    [Header("Display on Hover")]
+    [SerializeField] GameObject ToggleDescParent;
+    [SerializeField] public TextMeshProUGUI DisplayName;
+    [SerializeField] public TextMeshProUGUI DisplayDescription;
+    [SerializeField] public TextMeshProUGUI DisplayLevel;
+    //
+    [Header("Price")]
+    [SerializeField] public TextMeshProUGUI PriceDisplay;
+    [SerializeField] public int Price;
+    private Button button;
+
+    void Start()
+    {
+        if(augmentScript == null)
+        {
+            Debug.Log("No Augment Scriptable Object referenced!");
+            return;
+        }
+        allowInput = false;
+
+        // RefreshInfo();
+
+        if(!alwaysDisplay) ToggleDescriptionDisplay(false);
+        else ToggleDescriptionDisplay(true);
+    }
+
+    void OnEnable()
+    {
+        if(selectMenu == null) selectMenu = GetComponentInParent<AugmentSelectMenu>();
+        ToggleOverlay(false);
+        RefreshInfo();
+        StartCoroutine(RevealAugment());
+    }
+
+    void Update()
+    {
+        //TODO: TESTING, DELETE, should be displaying on MouseHoverOver
+        if(Input.GetKeyDown(KeyCode.B)) //works
+        {
+            bool currToggle = ToggleDescParent.activeSelf;
+            ToggleDescriptionDisplay(!currToggle);
+        }
+    }
+    
+    private void ToggleOverlay(bool toggle)
+    {
+        if(selectedOverlay == null) return;
+        selectedOverlay.SetActive(toggle);
+    }
+
+    IEnumerator RevealAugment()
+    {
+        // yield return new WaitForSecondsRealtime(.2f);
+        //TODO: start animation here
+        // yield return new WaitForSecondsRealtime(.2f); //Animation time
+        yield return new WaitForSecondsRealtime(.1f); //Animation time
+        ToggleOverlay(false);
+        allowInput = true;
+    }
+
+    public void SelectAugment()
+    {
+        if(!allowInput) return;
+        if(selectMenu.isShop)
+        {
+            if(Price > GameManager.Instance.Inventory.goldAmount) return; //Player can't afford
+            GameManager.Instance.Inventory.UpdateGold(-Price); //Take gold from player, update display
+        }
+
+        allowInput = false;
+        selectMenu.SelectAugment(augmentScript);
+        ToggleOverlay(true);
+    }
+
+    public void RefreshInfo()
+    {
+        if(augmentScript == null) return;
+
+        ToggleOverlay(false);
+        DisplayName.text = augmentScript.Name;
+        AugmentIcon_Image.sprite = augmentScript.Icon_Image;
+        Border_Image.sprite = augmentScript.Border_Image;
+        DisplayDescription.text = augmentScript.Description;
+        DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
+        if(PriceDisplay != null) PriceDisplay.text = Price.ToString();
+        GetBorderColor();
+    }
+
+    public void UpdateColor(bool playerCanAfford)
+    {
+        if(playerCanAfford) PriceDisplay.color = Color.white;
+        else PriceDisplay.color = Color.red;
+    }
+
+    public void TogglePrice(bool toggle)
+    {
+        PriceDisplay.gameObject.SetActive(toggle);
+    }
+
+    public void ToggleDescriptionDisplay(bool toggle)
+    {
+        //Always display when in a Shop
+        //Only display on mouse hover when in inventory
+        ToggleDescParent.SetActive(toggle);
+    }
+
+    public void ToggleAugmentDisplay(bool toggle)
+    {
+        if(FullDisplayParent == null) return;
+        FullDisplayParent.SetActive(toggle);
+    }
+
+    private void GetBorderColor()
+    {
+        switch(augmentScript.Tier)
+        {
+            case 0: //Common
+                Border_Image.color = Color.white;
+                break;
+            case 1: //Rare
+                Border_Image.color = new Color(0, 1, 0.2991796f); //Green
+                break;
+            case 2: //Epic
+                Border_Image.color = new Color(0.6988888f, 0, 1); //Purple
+                break;
+            case 3: //Legendary
+                Border_Image.color = new Color(1, 0.4445357f, 0.1745283f); //Orange
+                break;
+            case 4: //Overcharged
+                Border_Image.color = Color.cyan;
+                break;
+            case 5: //Unstable
+                Border_Image.color = Color.red;
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/_Augments/AugmentDisplay.cs.meta
+++ b/_Augments/AugmentDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f1d0ac5a02fd2d4790b6dd8612d2164
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/AugmentInventoryDisplay.cs
+++ b/_Augments/AugmentInventoryDisplay.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AugmentInventoryDisplay : MonoBehaviour
+{
+    [SerializeField] public AugmentDisplay[] AugmentSlots;
+    public int numSlots;
+
+    void Start()
+    {
+        // if(AugmentSlots.Length == 0) return;
+        ToggleSlots();
+    }
+
+    public void AddAugmentToDisplay(List<AugmentScript> augmentList)
+    {
+        numSlots = augmentList.Count;
+
+        for(int i=0; i<numSlots; i++)
+        {
+            AugmentSlots[i].augmentScript = augmentList[i];
+        }
+
+        ToggleSlots();
+    }
+
+    public void ToggleSlots()
+    {
+        numSlots = AugmentSlots.Length;
+        for(int i=0; i<numSlots; i++)
+        {
+            var augSlot = AugmentSlots[i].GetComponent<AugmentDisplay>();
+            if(augSlot.augmentScript != null) AugmentSlots[i].gameObject.SetActive(true);
+            else AugmentSlots[i].gameObject.SetActive(false);
+        }
+    }
+}

--- a/_Augments/AugmentInventoryDisplay.cs.meta
+++ b/_Augments/AugmentInventoryDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 034c820e819147f40ad80611d541b976
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -70,7 +70,9 @@ public class AugmentPool : MonoBehaviour
     public void RandomizeAugmentStats(AugmentScript augment)
     {
         //Can be called from other scripts if the Player wants to reroll the Level
-        augment.AugmentLevel = Random.Range(1, 6); //maxExclusive
+        int randLevel = RandomAugmentLevel(); //maxExclusive
+        augment.UpdateLevel(randLevel);
+
         //TODO: Need weights for each Level
     }
 
@@ -100,40 +102,22 @@ public class AugmentPool : MonoBehaviour
         else SwapAugmentList(augment, shopListedAugments, ownedAugments);
     }
 
-    //////////////////// TODO: TESTING
-    void Update()
-    {
-        if(Input.GetKeyDown(KeyCode.L))
-        {
-            for(int i=0; i<100; i++)
-            {
-                RandomAugmentTier();
-            }
-        }
-    }
-
-    ///////////////////////////////////////////////////
-
     public int RandomAugmentTier()
     {
-        int augmentTier;
+        int augmentTier; //1-5
         float rand = Random.Range(0f, 1.01f);
-        // float rand = Random.Range(0f, 1f);
         
-        
-        if(rand >= .58f) {augmentTier = 1; Debug.Log("Common - 42%");}
-        else if(rand >= .27f) {augmentTier = 2; Debug.Log("Rare - 32%");}
-        else if(rand >= .8f) {augmentTier = 3; Debug.Log("Epic - 19%");}
-        else if(rand >= .1f) {augmentTier = 4; Debug.Log("Legendary - 5%");} //6
-        else {augmentTier = 5; Debug.Log("Oc/Un - 2%");} //1%
+        if(rand >= .50f) augmentTier = 0; //Common - 50%
+        else if(rand >= .20f) augmentTier = 1; //Rare - 30%
+        else if(rand >= .04f) augmentTier = 2; //Epic - 16%
+        else if(rand >= .01f) augmentTier = 3; //Legendary - 3%
+        else{ //Overcharged or Unstable - 1%
+            rand = Random.Range(0f, 1.0f);
+            if(rand >= .5f) augmentTier = 4;
+            else augmentTier = 5;
+        }
 
         return augmentTier;
-        // Common 42%
-        // Rare 32%
-        // Epic	19%
-        // Legendary 5%
-        // Overcharged 1% (50/50 to be Unstable)
-        // Unstable 1% (50/50 to be Overcharged)
     }
 
     public int RandomAugmentLevel()
@@ -141,21 +125,14 @@ public class AugmentPool : MonoBehaviour
         int augmentLevel = 1; //1-5
         float rand = Random.Range(0f, 1.01f);
         
-        if(rand >= .58f) augmentLevel = 1; //TODO: change weights
-        else if(rand >= .27f) augmentLevel = 2;
-        else if(rand >= .8f) augmentLevel = 3;
-        else if(rand >= .1f) augmentLevel = 4;
-        else augmentLevel = 5;
+        if(rand >= .50f) augmentLevel = 1; //- 50%
+        else if(rand >= .20f) augmentLevel = 2; //- 30%
+        else if(rand >= .04f) augmentLevel = 3; //- 16%
+        else if(rand >= .01f) augmentLevel = 4; //- 3%
+        else augmentLevel = 5; //- 1%
 
         return augmentLevel;
-        // Level 1 42%
-        // Level 2 32%
-        // Level 3	19%
-        // Level 4 5%
-        // Level 5 2%
     }
-
-    ////////////////////
 
     public void EmptyStock()
     {

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -1,0 +1,196 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AugmentPool : MonoBehaviour
+{
+    //Pool of possible augments that can be found, can changed based on tileset
+
+    public int totalUnownedAugments;
+    public int totalOwnedAugments;
+    
+    [Header("Augment pools")]
+    public List<AugmentScript> unownedAugments; //available augments that haven't been picked yet
+    public List<AugmentScript> ownedAugments; //picked augments and can be pulled from with a higher level
+    public List<AugmentScript> shopListedAugments; //augments being listed in the Shop, temporarily filled to prevent duplicates
+    
+    public List<AugmentScript> tempPool; //TODO: when adding augments to the Shop or Rewards menu, hold here to prevent duplicates
+
+    void Awake()
+    {
+        UpdatePoolSizes();
+    }
+
+    private void UpdatePoolSizes()
+    {
+        totalUnownedAugments = unownedAugments.Count;
+        totalOwnedAugments = ownedAugments.Count;
+    }
+
+    public AugmentScript GetNewAugment()
+    {
+        UpdatePoolSizes(); //Update count for randIndex
+
+        if(totalUnownedAugments == 0 && totalOwnedAugments == 0)
+        {
+            Debug.Log("AugmentPool is empty!");
+            return null;
+        }
+
+        //Get a duplicate augment if the Player has all unique augments
+        if(totalUnownedAugments == 0)
+        {
+            return GetNewDuplicateAugment();
+        }
+        else //Get random index of unowned augments, and randomize level
+        {
+            int randIndex = Random.Range(0, unownedAugments.Count);//totalUnownedAugments);
+            var newAugment = unownedAugments[randIndex];
+            newAugment.AugmentLevel = Random.Range(0, 6); //0-5
+            SwapAugmentList(newAugment, unownedAugments, tempPool);
+            UpdatePoolSizes(); //Update again for referenced counts
+            return newAugment;
+        }
+    }
+
+    public AugmentScript GetAugmentFromPool()//List<AugmentScript> augmentList)
+    {
+        //Add augments at random index into tempPool
+        List<AugmentScript> poolList;
+        if(unownedAugments.Count == 0) poolList = ownedAugments;
+        else poolList = unownedAugments;
+
+        int randIndex = Random.Range(0, poolList.Count);
+        AugmentScript augmentFromPool = poolList[randIndex];
+        RandomizeAugmentStats(augmentFromPool);
+
+        return augmentFromPool;
+    }
+
+    public void RandomizeAugmentStats(AugmentScript augment)
+    {
+        //Can be called from other scripts if the Player wants to reroll the Level
+        augment.AugmentLevel = Random.Range(1, 6); //maxExclusive
+        //TODO: Need weights for each Level
+    }
+
+    public void SwapAugmentList(AugmentScript addedAugment, List<AugmentScript> newList, List<AugmentScript> prevList, bool selected = true)
+    {
+        //Moves an Augment from one list to another
+        newList.Add(addedAugment);
+        prevList.Remove(addedAugment);
+    }
+
+    public void ChooseAugment(AugmentScript chosenAugment)
+    {
+        //Check location of chosen augment
+        //Move to ownedAugments if not already owned (duplicate)
+        if(unownedAugments.Contains(chosenAugment))
+            SwapAugmentList(chosenAugment, ownedAugments, unownedAugments);
+        
+        //Augment was chosen, move the remaining listed augments back to unowned
+        //EmptyStock() is called in AugmentSelectMenu.SelectAugment()
+    }
+
+    public void StockShop(AugmentScript augment, bool unowned = true)
+    {
+        //Move augment from unownedPool into shopListedAugments
+        //This prevents duplicates
+        if(unowned) SwapAugmentList(augment, shopListedAugments, unownedAugments);
+        else SwapAugmentList(augment, shopListedAugments, ownedAugments);
+    }
+
+    //////////////////// TODO: TESTING
+    void Update()
+    {
+        if(Input.GetKeyDown(KeyCode.L))
+        {
+            for(int i=0; i<100; i++)
+            {
+                RandomAugmentTier();
+            }
+        }
+    }
+
+    ///////////////////////////////////////////////////
+
+    public int RandomAugmentTier()
+    {
+        int augmentTier;
+        float rand = Random.Range(0f, 1.01f);
+        // float rand = Random.Range(0f, 1f);
+        
+        
+        if(rand >= .58f) {augmentTier = 1; Debug.Log("Common - 42%");}
+        else if(rand >= .27f) {augmentTier = 2; Debug.Log("Rare - 32%");}
+        else if(rand >= .8f) {augmentTier = 3; Debug.Log("Epic - 19%");}
+        else if(rand >= .1f) {augmentTier = 4; Debug.Log("Legendary - 5%");} //6
+        else {augmentTier = 5; Debug.Log("Oc/Un - 2%");} //1%
+
+        return augmentTier;
+        // Common 42%
+        // Rare 32%
+        // Epic	19%
+        // Legendary 5%
+        // Overcharged 1% (50/50 to be Unstable)
+        // Unstable 1% (50/50 to be Overcharged)
+    }
+
+    public int RandomAugmentLevel()
+    {
+        int augmentLevel = 1; //1-5
+        float rand = Random.Range(0f, 1.01f);
+        
+        if(rand >= .58f) augmentLevel = 1; //TODO: change weights
+        else if(rand >= .27f) augmentLevel = 2;
+        else if(rand >= .8f) augmentLevel = 3;
+        else if(rand >= .1f) augmentLevel = 4;
+        else augmentLevel = 5;
+
+        return augmentLevel;
+        // Level 1 42%
+        // Level 2 32%
+        // Level 3	19%
+        // Level 4 5%
+        // Level 5 2%
+    }
+
+    ////////////////////
+
+    public void EmptyStock()
+    {
+        StartCoroutine(EmptyStockCO());
+    }
+
+    public IEnumerator EmptyStockCO()
+    {
+        // if(shopListedAugments.Count == 0) Debug.Log("shoplistedaugments is empty"); //TODO: !!
+        // else Debug.Log("shopListed Count: " + shopListedAugments.Count);
+
+        while(shopListedAugments.Count > 0)
+        {
+            //Move from shopListed to unowned
+            SwapAugmentList(shopListedAugments[0], unownedAugments, shopListedAugments, false);
+            yield return new WaitForSecondsRealtime(.01f);
+        }
+        UpdatePoolSizes();
+        yield return new WaitForSecondsRealtime(.1f);
+    }
+
+    public AugmentScript GetNewDuplicateAugment()
+    {
+        UpdatePoolSizes();
+
+        if(totalOwnedAugments == 0) return GetNewAugment();
+
+        int randIndex = Random.Range(0, ownedAugments.Count);//totalOwnedAugments);
+        var duplicateAugment = ownedAugments[randIndex];
+
+        duplicateAugment.AugmentLevel = Random.Range(0, 6); //0-5, maxExclusive
+        //TODO: add weights, should be more likely to roll lower
+        SwapAugmentList(duplicateAugment, ownedAugments, tempPool);
+        
+        UpdatePoolSizes();
+        return duplicateAugment;
+    }
+}

--- a/_Augments/AugmentPool.cs.meta
+++ b/_Augments/AugmentPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a40355e8f15c4b047960ac4c6548a843
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/AugmentPoolHelper.cs
+++ b/_Augments/AugmentPoolHelper.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AugmentPoolHelper : MonoBehaviour
+{
+    [Header("All Augment Pools")]
+    [SerializeField] public List<AugmentScript> augmentsList;
+    public int totalAugments;
+
+    void Start()
+    {
+        UpdateCount();
+    }
+
+    private void UpdateCount()
+    {
+        totalAugments = augmentsList.Count;
+    }
+    
+    public AugmentScript GetRandomAugment()
+    {
+        UpdateCount();
+        AugmentScript augment;
+        int randIndex = Random.Range(0, totalAugments); //maxExclusive, but works for index
+        augment = augmentsList[randIndex];
+        return augment;
+    }
+
+    public bool IsEmpty()
+    {
+        UpdateCount();
+        return totalAugments == 0;
+    }
+
+    public bool ListContains(AugmentScript augment)
+    {
+        return augmentsList.Contains(augment);
+    }
+
+//TODO: might not be needed, SwapAugmentList handles this
+    public void RemoveAugment(AugmentScript augment)
+    {
+        augmentsList.Remove(augment);
+    }
+
+    public void ReturnAugment(AugmentScript augment)
+    {
+        augmentsList.Add(augment);
+    }
+}

--- a/_Augments/AugmentPoolHelper.cs.meta
+++ b/_Augments/AugmentPoolHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 766ff0b5d87637246867ca367daf0e12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -45,11 +45,11 @@ public class AugmentScript : MonoBehaviour
         if(augmentScrObj == null) { Debug.Log("No Augment Scriptable Object referenced!"); return; }
         Name = augmentScrObj.Name;
         Icon_Image = augmentScrObj.AugmentIcon;
-        Description = augmentScrObj.Description; //TODO: setup for mouse hover
+        Description = augmentScrObj.Description;
         BuffedStat = (int)augmentScrObj.BuffedStat;
         buffedAmount = augmentScrObj.StatIncrease;
         Debug.Log("Augment Stats loaded");
-        // DebuffedStat = augmentScrObj. //TODO: might just use "modifiedStat", use + or - for changes
+        // DebuffedStat = augmentScrObj. //TODO: might just use "modifiedStat", then use + or - for changes
     }
 //
  

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -11,7 +11,7 @@ public class AugmentScript : MonoBehaviour
 
     [Header("Stats from Scriptable Object")]
     public int Tier; //0: Common, 1: Rare, 2: Epic, 3: Legendary, 4: Overcharged, 5: Unstable
-    public int AugmentLevel; //Randomized in AugmentSelectMenu, 0-5
+    public int AugmentLevel; //Randomized in AugmentSelectMenu, 1-5
     public int BuffedStat;
     public float buffedAmount;
     public float buffedAmountPercent;
@@ -20,7 +20,6 @@ public class AugmentScript : MonoBehaviour
     public float debuffedAmountPercent;
     [Header("Icons")]
     [SerializeField] public Sprite Icon_Image;
-    [SerializeField] public Sprite Border_Image; //TODO: might not use 
 
     [Header("Display - Set by reference")]
     [SerializeField] public string Name;
@@ -57,8 +56,7 @@ public class AugmentScript : MonoBehaviour
 
     public void UpdateLevel(int level)
     {
-        if(level == AugmentLevel) return;
-
+        AugmentLevel = level;
         UpdateStatsToLevel();
     }
 
@@ -67,8 +65,12 @@ public class AugmentScript : MonoBehaviour
     private void UpdateStatsToLevel()
     {
         // if(AugmentLevel >= augmentScrObj.MaxUpgradeLevel) return;
+        int scaledLevel = (AugmentLevel - 1);
         //Upgrade stats
-
+        if(buffedAmount != 0) buffedAmount += scaledLevel;
+        if(buffedAmountPercent != 0f) buffedAmountPercent += scaledLevel * .02f;
+        if(debuffedAmount != 0) debuffedAmount -= scaledLevel;
+        if(debuffedAmountPercent != 0f) debuffedAmountPercent += scaledLevel * .02f;
     }
 
 #endregion

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class AugmentScript : MonoBehaviour
+{
+    [Header("Scriptable Object Reference")]
+    [SerializeField] public Augment augmentScrObj;
+
+    [Header("Stats from Scriptable Object")]
+    public int Tier; //0: Common, 1: Rare, 2: Epic, 3: Legendary, 4: Overcharged, 5: Unstable
+    public int AugmentLevel; //Randomized in AugmentSelectMenu, 0-5
+    public int BuffedStat;
+    public float buffedAmount;
+    public float buffedAmountPercent;
+    public int DebuffedStat;
+    public float debuffedAmount;
+    public float debuffedAmountPercent;
+    [Header("Icons")]
+    [SerializeField] public Sprite Icon_Image;
+    [SerializeField] public Sprite Border_Image; //TODO: might not use 
+
+    [Header("Display - Set by reference")]
+    [SerializeField] public string Name;
+    [Multiline(10)]
+    [SerializeField] public string Description;
+
+
+    void Awake()
+    {
+        // if(Description == null) Description = GetComponentInChildren<TextMeshProUGUI>();
+        if(augmentScrObj == null) return;
+        AugmentLevel = augmentScrObj.MinLevel; //Min level is determined by its tier;
+        GetAugmentVariables();
+    }
+
+    void Start()
+    {
+
+    }
+
+    private void GetAugmentVariables()
+    {
+        if(augmentScrObj == null) { Debug.Log("No Augment Scriptable Object referenced!"); return; }
+        Name = augmentScrObj.Name;
+        Icon_Image = augmentScrObj.AugmentIcon;
+        Description = augmentScrObj.Description; //TODO: setup for mouse hover
+        BuffedStat = (int)augmentScrObj.BuffedStat;
+        buffedAmount = augmentScrObj.StatIncrease;
+        Debug.Log("Augment Stats loaded");
+        // DebuffedStat = augmentScrObj. //TODO: might just use "modifiedStat", use + or - for changes
+    }
+//
+ 
+
+    public void UpdateLevel(int level)
+    {
+        if(level == AugmentLevel) return;
+
+        UpdateStatsToLevel();
+    }
+
+
+#region Change Stats based on Level
+    private void UpdateStatsToLevel()
+    {
+        // if(AugmentLevel >= augmentScrObj.MaxUpgradeLevel) return;
+        //Upgrade stats
+
+    }
+
+#endregion
+
+}

--- a/_Augments/AugmentScript.cs.meta
+++ b/_Augments/AugmentScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5949277a6f2b8d84c8dbe74991a2b394
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/AugmentSelectMenu.cs
+++ b/_Augments/AugmentSelectMenu.cs
@@ -1,0 +1,208 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+
+public class AugmentSelectMenu : MonoBehaviour
+{
+    //Menu displayed when the Player can choose an Augment
+    //This is used for either 
+    //  the Reward to [Choose] a free Augment
+    //  the Shop menu to [Buy] an Augment
+    [SerializeField] ShopController shopController;
+    [SerializeField] AugmentInventory augmentInventory;
+    [SerializeField] AugmentPool pool;
+    [SerializeField] GameObject refreshingStockOverlay;
+    private bool allowInput;
+
+    [Header("SHOP or REWARD")]
+    [SerializeField] public bool isShop = false;
+    [SerializeField] public bool duplicates = false;
+
+    [Header("Refresh Cost")]
+    [SerializeField] public bool refreshAllowed = false;
+    [SerializeField] public int refreshCost = 100;
+    [SerializeField] TextMeshProUGUI refreshButtonText;
+
+    [Header("Augment Slots")]
+    [SerializeField] AugmentDisplay[] menuSlots;
+    [SerializeField] public List<AugmentScript> augmentsInStock;
+
+    [Header("=== Shop ===")]
+    [SerializeField] int[] prices; //Includes prices for all augments based on Tier
+
+    private int totalAugments = 3;
+    private bool refreshingStock;
+    public bool augmentSelected;
+    private bool initialStockDone = false;
+    
+    void Awake()
+    {
+        augmentSelected = false;
+        initialStockDone = false;
+        totalAugments = menuSlots.Length;
+        prices = new int[totalAugments];
+        refreshingStock = false;
+        allowInput = true;
+        if(shopController == null) shopController = transform.parent.GetComponentInParent<ShopController>();
+        if(pool == null) pool = shopController.augmentPool;
+    }
+
+    void OnEnable()
+    {
+        allowInput = true;
+        InitialStock();
+        GameManager.Instance.Pause.PauseTimeOnly();
+
+        //If refresh isn't allowed, disable the button, otherwise update the displayed Refresh Cost text
+        if(!refreshAllowed) refreshButtonText.transform.parent.gameObject.SetActive(false);
+        else if(refreshButtonText != null) refreshButtonText.text = refreshCost.ToString();
+    }
+
+    void OnDisable()
+    {
+        GameManager.Instance.Pause.Resume();
+        // pool.EmptyStock();
+    }
+
+    private void InitialStock()
+    {
+        if(initialStockDone) return;
+        if(pool == null) return;
+        if(refreshingStock) return;
+        StartCoroutine(RefreshStockCO());
+        initialStockDone = true;
+    }
+
+    public void RefreshStock()
+    {
+        if(pool == null) return;
+        if(!allowInput) return;
+        if(!refreshAllowed || GameManager.Instance.Inventory.goldAmount < refreshCost) return;
+        GameManager.Instance.Inventory.UpdateGold(-refreshCost);
+
+        StartCoroutine(RefreshStockCO());
+    }
+
+    IEnumerator RefreshStockCO()
+    {
+        refreshingStock = true;
+        refreshingStockOverlay.SetActive(true);
+
+        for(int i=0; i<totalAugments; i++)
+        {
+            menuSlots[i].ToggleAugmentDisplay(false);
+        }
+
+        //Check if pool is filled before calling EmptyStockCO
+        if(pool.shopListedAugments.Count > 0) yield return pool.EmptyStockCO();
+
+        augmentsInStock.Clear();
+
+        for(int i=0; i<totalAugments; i++)
+        {
+            AugmentScript currAugment = pool.GetAugmentFromPool();
+            augmentsInStock.Add(currAugment); //Local list
+            yield return new WaitForSecondsRealtime(.01f);
+            pool.StockShop(currAugment); //Pool list
+            if(isShop) prices[i] = GetPrice(augmentsInStock[i]);
+        }
+
+        yield return new WaitForSecondsRealtime(.1f);
+
+        pool.EmptyStock();
+        UpdateDisplay();
+
+        for(int i=0; i<totalAugments; i++)
+        {
+            menuSlots[i].ToggleAugmentDisplay(true);
+        }
+        
+        refreshingStock = false;
+        refreshingStockOverlay.SetActive(false);
+    }
+
+    public void SelectAugment(AugmentScript augment)
+    {
+        if(!allowInput) return;
+        if(augmentInventory == null) augmentInventory = GameManager.Instance.AugmentInventory;
+        pool.ChooseAugment(augment);
+        //Add the selected Augment into the Player's inventory
+        augmentInventory.AddAugment(augment);
+
+        //Disable input for selecting Augments
+        for(int i=0; i<totalAugments; i++) menuSlots[i].allowInput = false;
+
+        UpdateDisplay(); //Updates price colors if player buys something
+
+        //Disable inputs to close the Menu after one Augment was selected
+        allowInput = false;
+        augmentSelected = true;
+        shopController.oneTimePurchaseDone = true;
+
+        StartCoroutine(DisableSelectMenu(.5f));
+    }
+
+    IEnumerator DisableSelectMenu(float delay)
+    {
+        yield return new WaitForSecondsRealtime(delay);
+        transform.parent.gameObject.SetActive(false);
+    }
+
+    void UpdateDisplay()
+    {
+        for(int i=0; i<menuSlots.Length; i++)
+        {
+            var currAugSlot = menuSlots[i].GetComponent<AugmentDisplay>();
+
+            currAugSlot.alwaysDisplay = isShop;
+            currAugSlot.augmentScript = augmentsInStock[i];
+
+            if(isShop)
+            {
+                //Display Price
+                currAugSlot.Price = prices[i];
+                //Price is red if Player can't afford
+                if(prices[i] > GameManager.Instance.Inventory.goldAmount)
+                    currAugSlot.UpdateColor(false);
+                else
+                    currAugSlot.UpdateColor(true);
+            }
+            else //Hide Prices (0)
+            {
+                currAugSlot.TogglePrice(false);
+            }
+            currAugSlot.RefreshInfo();
+        }
+    }
+
+    private int GetPrice(AugmentScript augment)
+    {
+        //TODO: None of these values are balanced, just placeholder
+        int totalPrice = 0;
+
+        switch(augment.Tier)
+        {
+            case 0: totalPrice = 15; break;
+            case 1: totalPrice = 30; break;
+            case 2: totalPrice = 60; break;
+            case 3: totalPrice = 120; break;
+            case 4: totalPrice = 240; break;
+            case 5: totalPrice = 360; break;
+            default: totalPrice = 0; break;
+        }
+
+        switch(augment.AugmentLevel)
+        {
+            case 0: totalPrice += 5; break;
+            case 1: totalPrice += 10; break;
+            case 2: totalPrice += 20; break;
+            case 3: totalPrice += 40; break;
+            case 4: totalPrice += 80; break;
+            case 5: totalPrice += 160; break;
+            default: break;
+        }
+
+        return totalPrice;
+    }
+}

--- a/_Augments/AugmentSelectMenu.cs.meta
+++ b/_Augments/AugmentSelectMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09cc0437f5560f445858bf4b06426b31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Enemy Scripts/OrbController.cs
+++ b/_Enemy Scripts/OrbController.cs
@@ -10,7 +10,6 @@ public class OrbController : MonoBehaviour
 
     [Header("Debugging")]
     [SerializeField] private bool findPlayer;
-    [SerializeField] private float timeSpentFlying;
 
     [Space(10)]
 
@@ -36,7 +35,6 @@ public class OrbController : MonoBehaviour
         rb = GetComponent<Rigidbody2D>();
         collider = GetComponent<CircleCollider2D>();
         findPlayer = false;
-        timeSpentFlying = 0;
 
         xV = Random.Range(xVelocityLower, xVelocityUpper);
         yV = Random.Range(yVelocityLower, yVelocityUpper);
@@ -59,8 +57,8 @@ public class OrbController : MonoBehaviour
     {
         if (!findPlayer) return;
 
-        timeSpentFlying += Time.deltaTime * 4f;
-        var step = (orbSpeed + timeSpentFlying) * Time.deltaTime;
+        orbSpeed *= 1.08f;
+        var step = orbSpeed * Time.deltaTime;
         transform.position = Vector3.MoveTowards(transform.position, player.position, step);
 
         if(Vector3.Distance(transform.position, player.position) < 0.1f)
@@ -73,7 +71,6 @@ public class OrbController : MonoBehaviour
     {
         if (player != null) yield return null;
         yield return new WaitForSeconds(startChaseDelay);
-        timeSpentFlying = .1f;
         DisableColliderGrav();
     }
 

--- a/_Enemy Scripts/OrbController.cs
+++ b/_Enemy Scripts/OrbController.cs
@@ -61,7 +61,7 @@ public class OrbController : MonoBehaviour
         var step = orbSpeed * Time.deltaTime;
         transform.position = Vector3.MoveTowards(transform.position, player.position, step);
 
-        if(Vector3.Distance(transform.position, player.position) < 0.1f)
+        if(Vector3.Distance(transform.position, player.position) < 0.2f)
         {
             HitPlayer();
         }

--- a/_Manager Handler Scripts/Testing/EnemySpawner.cs
+++ b/_Manager Handler Scripts/Testing/EnemySpawner.cs
@@ -7,6 +7,8 @@ public class EnemySpawner : MonoBehaviour
     [SerializeField] Transform spawnOffset;
     [SerializeField] Animator anim;
 
+    [Header("Custom Variables")]
+    [SerializeField] int totalSpawns = 1;
 
     void Start()
     {
@@ -15,6 +17,9 @@ public class EnemySpawner : MonoBehaviour
 
     public void SpawnEnemy()
     {
-        Instantiate(enemyPrefab, spawnOffset.position, Quaternion.identity);
+        for(int i=0; i<totalSpawns; i++)
+        {
+            Instantiate(enemyPrefab, spawnOffset.position, Quaternion.identity);
+        }
     }
 }


### PR DESCRIPTION
### AugmentPool
- AugmentPoolHelper
  - Manages each Tier's separate augment pool (6 total Tiers)
  - AugmentPool is updated to pull from a random Tier augment pool instead of one giant pool
  - Added a check when picking Tiers to make sure the List isn't empty, will reroll the Tier if it is.
- Augment Tiers and Levels
  - Added weighted probabilities for randomly picked Augments
    - Lower Tiers are more likely to be added compared to higher Tiers, etc
  - Levels are also randomized with different weights

### AugmentSelect
- Augments will now be added temporarily to the Shop's list to prevent duplicates
  - Augments are removed once the 3 augments are picked
    - Augments no longer have to be returned, and are only swapped if picked
- Fixed AugmentSelect's Augments being refreshed when re-opened

### Misc
- OrbController now doubles speed every second until it reaches the Player
- Moved all Augment-related scripts to the Augment folder