### PR TITLE
Duplicate Augments

### DIFF
--- a/_Augments/Augment.cs
+++ b/_Augments/Augment.cs
@@ -12,7 +12,12 @@ public class Augment : ScriptableObject
     public enum _Tier { Common, Rare, Epic, Legendary, Overcharged, Unstable };
     // public int Tier = 0; //0: Common, 1: Rare, 2: Epic, 3: Legendary, 4: Overcharged, 5: Unstable
     public _Tier Tier; //0: Common, 1: Rare, 2: Epic, 3: Legendary, 4: Overcharged, 5: Unstable
-    public int MinLevel = 1; //TODO: might not use this system
+    // public int MaxLevel = 5; 
+
+    // public enum _MaxLevel { Level1 = 1, Level2 = 2, Level3 = 3, Level4 = 5, Level5 = 5};
+    // public _MaxLevel MaxLevel; //TODO: might not use this system //FIX: Level5 can't be selected
+    public int MaxLevel = 5; //TODO: might not use this system
+
     public Sprite AugmentIcon;
     public string Name;
     [Multiline(10)]

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -13,6 +13,7 @@ public class AugmentDisplay : MonoBehaviour
     [Space(10)]
     [Header("Display Toggles")]
     [SerializeField] GameObject selectedOverlay;
+    [SerializeField] private TextMeshProUGUI selectedOverlayText;
     [SerializeField] GameObject FullDisplayParent;
 
     [Space(10)]
@@ -47,6 +48,8 @@ public class AugmentDisplay : MonoBehaviour
 
         if(!alwaysDisplay) ToggleDescriptionDisplay(false);
         else ToggleDescriptionDisplay(true);
+
+        if(selectedOverlayText == null && selectedOverlay != null) selectedOverlayText = selectedOverlay.GetComponentInChildren<TextMeshProUGUI>();
     }
 
     void OnEnable()
@@ -56,21 +59,19 @@ public class AugmentDisplay : MonoBehaviour
         RefreshInfo();
         StartCoroutine(RevealAugment());
     }
-
-    void Update()
-    {
-        //TODO: TESTING, DELETE, should be displaying on MouseHoverOver
-        if(Input.GetKeyDown(KeyCode.B)) //works
-        {
-            bool currToggle = ToggleDescParent.activeSelf;
-            ToggleDescriptionDisplay(!currToggle);
-        }
-    }
     
-    private void ToggleOverlay(bool toggle)
+    public void ToggleOverlay(bool toggle, bool purchased = true)
     {
         if(selectedOverlay == null) return;
-        selectedOverlay.SetActive(toggle);
+
+        // selectedOverlay.SetActive(toggle);
+        
+        if(selectedOverlayText == null) return;
+        if(selectedOverlayText.IsActive())
+        {
+            if(purchased) selectedOverlayText.text = "Purchased"; //default
+            else selectedOverlayText.text = "Max Level";
+        }
     }
 
     IEnumerator RevealAugment()
@@ -97,7 +98,7 @@ public class AugmentDisplay : MonoBehaviour
         ToggleOverlay(true);
     }
 
-    public void RefreshInfo()
+    public void RefreshInfo(bool upgrade = false)
     {
         if(augmentScript == null) return;
 
@@ -105,7 +106,12 @@ public class AugmentDisplay : MonoBehaviour
         DisplayName.text = augmentScript.Name;
         AugmentIcon_Image.sprite = augmentScript.Icon_Image;
         DisplayDescription.text = augmentScript.Description;
-        DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
+
+        // DisplayLevel.text = "Lv" + augmentScript.AugmentLevel; //default
+
+        if(upgrade) DisplayLevel.text = "Lv" + ((int)augmentScript.AugmentLevel+1); //TODO: testing, needs update/refresh
+        else DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
+
         if(PriceDisplay != null) PriceDisplay.text = Price.ToString();
         GetBorderColor();
     }

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -141,15 +141,12 @@ public class AugmentPool : MonoBehaviour
     public void RandomizeAugmentStats(AugmentScript augment)
     {
         //Check if Augment is already listed
-        if(CheckIfListed(augment))
-        {
-            Debug.Log("found duplicate, no random stats"); //TODO: works, remove when done
-            return;
-        }
+        if(CheckIfListed(augment)) return;
 
         //Can be called from other scripts if the Player wants to reroll the Level/stats
         int randLevel = RandomAugmentLevel();
         augment.UpdateLevel(randLevel); //Updates stats to Level
+        // augment.UpdateLevel(5); //Updates stats to Level //TODO: DEBUGGING
     }
 
     private int RandomAugmentTier()

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -7,7 +7,7 @@ public class AugmentPool : MonoBehaviour
     //Manager Script
     //Pool of possible augments that can be found, can changed based on tileset
 
-    public int totalUnownedAugments;
+    // public int totalUnownedAugments;
     public int totalOwnedAugments;
 
     [Header("Augment Lists by Tier")]
@@ -15,12 +15,14 @@ public class AugmentPool : MonoBehaviour
     
     [Header("Augment Lists")]
     public List<AugmentScript> ownedAugments; //picked augments and can be pulled from with a higher level
-    public List<AugmentScript> shopListedAugments; //augments being listed in the Shop, temporarily filled to prevent duplicates
+    public List<AugmentScript> listedAugmentsTEMP; //augments being listed in the Shop, temporarily filled to prevent duplicates
+    public List<AugmentScript> currentListedAugments; //holds all currently listed augments
+    [SerializeField] private AugmentInventory augmentInventory;
 
     void Start()
     {
-        // augmentPoolHelpers = new AugmentPoolHelper[6]; //Setup in Inspector
         UpdatePoolSizes();
+        if(augmentInventory == null) augmentInventory = GameManager.Instance.AugmentInventory;
     }
 
     private void UpdatePoolSizes()
@@ -33,19 +35,20 @@ public class AugmentPool : MonoBehaviour
         UpdatePoolSizes(); //Update count for randIndex
 
         //Get a duplicate augment if the Player has all unique augments
-        if(totalUnownedAugments == 0)
-        {
-            return GetNewDuplicateAugment();
-        }
-        else //Get random index of unowned augments, and randomize level
-        {
-            int currTier = RandomAugmentTier();
-            AugmentScript newAugment = augmentPoolHelpers[currTier].GetRandomAugment();
-            RandomizeAugmentStats(newAugment);
-            SwapAugmentList(newAugment, GetAugmentList(newAugment), shopListedAugments);
-            UpdatePoolSizes(); //Update again for referenced counts
-            return newAugment;
-        }
+        // if(totalUnownedAugments == 0)
+        // {
+        //     return GetNewDuplicateAugment();
+        // }
+        // else
+        // {
+        //Get random index of unowned augments, and randomize level
+        int currTier = RandomAugmentTier();
+        AugmentScript newAugment = augmentPoolHelpers[currTier].GetRandomAugment();
+
+        RandomizeAugmentStats(newAugment);
+        SwapAugmentList(newAugment, GetAugmentList(newAugment), listedAugmentsTEMP);
+        UpdatePoolSizes(); //Update again for referenced counts
+        return newAugment;
     }
 
     public AugmentScript GetAugmentFromPool()//List<AugmentScript> augmentList)
@@ -70,26 +73,51 @@ public class AugmentPool : MonoBehaviour
         //Moves an Augment from one list to another
         newList.Add(addedAugment);
         currList.Remove(addedAugment);
+
+        if(newList == listedAugmentsTEMP)
+        {
+            currentListedAugments.Add(addedAugment); //Add a copy to listedAugments
+        }
     }
 
-    public void ChooseAugment(AugmentScript chosenAugment)
+    public void ChooseAugment(AugmentScript chosenAugment)//, int augmentLevel) //TODO: testing
     {
-        //Check if chosenAugment is already owned
-        if(ownedAugments.Contains(chosenAugment)) return;
-        //Move to ownedAugments if not already owned (duplicate)
-        //Else move back to original List
+        //Check if chosenAugment is already owned, remove old and reset stats
+        // Debug.Log("AugLvl: " + chosenAugment.AugmentLevel + ", ShopLvl: " + augmentLevel);
+        if(ownedAugments.Contains(chosenAugment))
+        {
+            augmentInventory.RemoveAugment(chosenAugment);
+        }
+        // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
         SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);
+
+        augmentInventory.AddAugment(chosenAugment);
         
         //Augment was chosen, move the remaining listed augments back to unowned
-        //EmptyStock() is called in AugmentSelectMenu.SelectAugment()
+        //EmptyStock() is called in FillStock()
+    }
+
+    public IEnumerator FillStock(List<AugmentScript> augmentsInStock, int totalAugments = 3)
+    {
+        for(int i=0; i<totalAugments; i++)
+        {
+            AugmentScript currAugment = GetAugmentFromPool();
+            
+            augmentsInStock.Add(currAugment); //AugmentSelectMenu //TODO:
+            
+            yield return new WaitForSecondsRealtime(.01f);
+            StockShop(currAugment); //Pool list //TODO: this should work
+        }
+        yield return new WaitForSecondsRealtime(.01f);
+        EmptyStock();
     }
 
     public void StockShop(AugmentScript augment, bool sellingDuplicates = true)
     {
-        //Move augment from unownedPool into shopListedAugments
+        //Move augment from unownedPool into shopListed
         //This prevents duplicates
-        if(sellingDuplicates) SwapAugmentList(augment, GetAugmentList(augment), shopListedAugments);
-        else SwapAugmentList(augment, ownedAugments, shopListedAugments);
+        if(sellingDuplicates) SwapAugmentList(augment, GetAugmentList(augment), listedAugmentsTEMP);
+        else SwapAugmentList(augment, ownedAugments, listedAugmentsTEMP);
     }
 
     private List<AugmentScript> GetAugmentList(AugmentScript augment)
@@ -104,12 +132,21 @@ public class AugmentPool : MonoBehaviour
         AugmentScript augment;
         int currTier = RandomAugmentTier();
         augment = augmentPoolHelpers[currTier].GetRandomAugment();
+        //Only randomize if not a duplicate
         RandomizeAugmentStats(augment);
+
         return augment;
     }
 
     public void RandomizeAugmentStats(AugmentScript augment)
     {
+        //Check if Augment is already listed
+        if(CheckIfListed(augment))
+        {
+            Debug.Log("found duplicate, no random stats"); //TODO: works, remove when done
+            return;
+        }
+
         //Can be called from other scripts if the Player wants to reroll the Level/stats
         int randLevel = RandomAugmentLevel();
         augment.UpdateLevel(randLevel); //Updates stats to Level
@@ -155,16 +192,33 @@ public class AugmentPool : MonoBehaviour
 
     public IEnumerator EmptyStockCO()
     {
-        while(shopListedAugments.Count > 0)
+        //Returns Augments to their original lists, and removes from shopListedAugments
+        while(listedAugmentsTEMP.Count > 0)
         {
             //Move from shopListed to unowned
-            AugmentScript currAugment = shopListedAugments[0];
+            AugmentScript currAugment = listedAugmentsTEMP[0];
             int augmentTier = currAugment.Tier;
-            SwapAugmentList(shopListedAugments[0], shopListedAugments, GetAugmentList(currAugment));
+            SwapAugmentList(listedAugmentsTEMP[0], listedAugmentsTEMP, GetAugmentList(currAugment));
             yield return new WaitForSecondsRealtime(.01f); //Realtime since game is paused
         }
         UpdatePoolSizes();
         yield return new WaitForSecondsRealtime(.1f);
+    }
+
+    public IEnumerator EmptyStockCO(List<AugmentScript> augmentsInStock)
+    {
+        for(int i=0; i<augmentsInStock.Count; i++)
+        {
+            currentListedAugments.Remove(augmentsInStock[i]);
+            yield return new WaitForSecondsRealtime(.01f); //Realtime since game is paused
+        }
+        UpdatePoolSizes();
+        yield return new WaitForSecondsRealtime(.1f);
+    }
+
+    public bool CheckIfListed(AugmentScript augment)
+    {
+        return currentListedAugments.Contains(augment);
     }
 
     public AugmentScript GetNewDuplicateAugment()
@@ -178,7 +232,7 @@ public class AugmentPool : MonoBehaviour
 
         RandomizeAugmentStats(duplicateAugment);
         
-        SwapAugmentList(duplicateAugment, ownedAugments, shopListedAugments);
+        SwapAugmentList(duplicateAugment, ownedAugments, listedAugmentsTEMP);
         
         UpdatePoolSizes();
         return duplicateAugment;

--- a/_Augments/AugmentPoolHelper.cs
+++ b/_Augments/AugmentPoolHelper.cs
@@ -22,7 +22,7 @@ public class AugmentPoolHelper : MonoBehaviour
     {
         UpdateCount();
         AugmentScript augment;
-        int randIndex = Random.Range(0, totalAugments); //maxExclusive, but works for index
+        int randIndex = Random.Range(0, totalAugments); //maxExclusive, works for index
         augment = augmentsList[randIndex];
         return augment;
     }

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -12,6 +12,7 @@ public class AugmentScript : MonoBehaviour
     [Header("Stats from Scriptable Object")]
     public int Tier; //0: Common, 1: Rare, 2: Epic, 3: Legendary, 4: Overcharged, 5: Unstable
     public int AugmentLevel; //Randomized in AugmentSelectMenu, 1-5
+    public int MaxLevel = 5;
     public int BuffedStat;
     public float buffedAmount;
     public float buffedAmountPercent;
@@ -31,7 +32,7 @@ public class AugmentScript : MonoBehaviour
     {
         // if(Description == null) Description = GetComponentInChildren<TextMeshProUGUI>();
         if(augmentScrObj == null) return;
-        AugmentLevel = augmentScrObj.MinLevel; //Min level is determined by its tier;
+        MaxLevel = augmentScrObj.MaxLevel; //Max level is determined by its tier;
         GetAugmentVariables();
     }
 

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -71,6 +71,8 @@ public class AugmentScript : MonoBehaviour
         if(buffedAmountPercent != 0f) buffedAmountPercent += scaledLevel * .02f;
         if(debuffedAmount != 0) debuffedAmount -= scaledLevel;
         if(debuffedAmountPercent != 0f) debuffedAmountPercent += scaledLevel * .02f;
+
+        //TODO: update description
     }
 
 #endregion

--- a/_Player Scripts/AugmentInventory.cs
+++ b/_Player Scripts/AugmentInventory.cs
@@ -90,6 +90,17 @@ public class AugmentInventory : MonoBehaviour
         combat.kbResist += modified_kbResist;
     }
 
+    private void ResetModifiedStats()
+    {
+        modified_MaxHP = 0;
+        modified_Defense = 0;
+        modified_MoveSpeed = 0;
+        modified_AttackDamage = 0;
+        modified_AttackSpeed = 0;
+        modified_KnockbackStrength = 0;
+        modified_kbResist = 0;
+    }
+
 #region Augments
     public void UpdateAugments()
     {
@@ -122,7 +133,9 @@ public class AugmentInventory : MonoBehaviour
     public void RemoveAugment(AugmentScript augment)
     {
         heldAugments.Remove(augment);
+        ResetModifiedStats();
         //TODO: need to return to pool
+        UpdateAugments();
     }
 
     private void ApplyAugmentStats(AugmentScript augment)


### PR DESCRIPTION
### Duplicate Augments
- Added a List currentListedAugments to keep track of all listed
Augments
- Duplicate augments won't have stats randomized, and can easily be
checked
- Menu Updates
- Augment overlay will now display "Purchased" once purchased and "Max
Level" if the Augment is already owned, and is at max level
- If the augment is not at max level, the Level will display "Lv ??" and
the level will be randomized if purchased
- "Owned" text will also be displayed to indicate the Augment is a
duplicate
- Bug fixes
  - Fixed issue with player stats not resetting when refreshing Augments