### PR TITLE
Duplicate Augments update

### DIFF
--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -12,6 +12,7 @@ public class AugmentDisplay : MonoBehaviour
 
     [Space(10)]
     [Header("Display Toggles")]
+    [SerializeField] bool inInventory = false;
     [SerializeField] GameObject selectedOverlay;
     [SerializeField] private TextMeshProUGUI selectedOverlayText;
     [SerializeField] private GameObject ownedText;
@@ -136,15 +137,24 @@ public class AugmentDisplay : MonoBehaviour
             if(selectMenu.IsOwned(augmentScript)) duplicate = true;
             else duplicate = false;
 
+            //Check for Duplicate augments not at Max level
             if(duplicate && !selectMenu.IsMaxLevel(augmentScript))
             {
                 DisplayLevel.text = "Lv ??";
+                
+                if(!inInventory) augmentScript.UpdateDescription(true);
+                else augmentScript.UpdateDescription();
+
                 if(ownedText != null) ownedText.SetActive(true);
                 randomizeLevel = true;
             }
-            else
+            else //Augment is not a Duplicate, or is Max Level
             {
                 DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
+                augmentScript.UpdateDescription();
+
+                if(ownedText != null) ownedText.SetActive(false);
+                randomizeLevel = false;
             }
         }
         else DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -35,9 +35,13 @@ public class AugmentDisplay : MonoBehaviour
     [SerializeField] public TextMeshProUGUI PriceDisplay;
     [SerializeField] public int Price;
     private Button button;
+    
+    [Header("Duplicate")]
+    [SerializeField] private bool randomizeLevel = false;
 
     void Start()
     {
+        randomizeLevel = false;
         if(augmentScript == null)
         {
             Debug.Log("No Augment Scriptable Object referenced!");
@@ -114,7 +118,7 @@ public class AugmentDisplay : MonoBehaviour
         }
 
         allowInput = false;
-        selectMenu.SelectAugment(augmentScript);
+        selectMenu.SelectAugment(augmentScript, randomizeLevel);
         ToggleOverlay(true);
     }
 
@@ -136,6 +140,7 @@ public class AugmentDisplay : MonoBehaviour
             {
                 DisplayLevel.text = "Lv ??";
                 if(ownedText != null) ownedText.SetActive(true);
+                randomizeLevel = true;
             }
             else
             {
@@ -146,6 +151,16 @@ public class AugmentDisplay : MonoBehaviour
         
         if(PriceDisplay != null) PriceDisplay.text = Price.ToString();
         GetBorderColor();
+    }
+
+    public void RefreshDisplayInfo()
+    {
+        if(augmentScript == null) return;
+
+        DisplayName.text = augmentScript.Name;
+        AugmentIcon_Image.sprite = augmentScript.Icon_Image;
+        DisplayDescription.text = augmentScript.Description;
+        DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
     }
 
     public void UpdateColor(bool playerCanAfford)

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -97,6 +97,28 @@ public class AugmentPool : MonoBehaviour
         //EmptyStock() is called in FillStock()
     }
 
+    public void ChooseAugment(AugmentScript chosenAugment, bool randomLevel) //TODO: testing
+    {
+        //Check if chosenAugment is already owned, remove old and reset stats
+        // Debug.Log("AugLvl: " + chosenAugment.AugmentLevel + ", ShopLvl: " + augmentLevel);
+        if(ownedAugments.Contains(chosenAugment))
+        {
+            Debug.Log("Augment is already owned");
+            augmentInventory.RemoveAugment(chosenAugment);
+            
+        }
+        
+        // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
+        RandomizeAugmentStats(chosenAugment);
+
+        // SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);
+
+        augmentInventory.AddAugment(chosenAugment);
+        
+        //Augment was chosen, move the remaining listed augments back to unowned
+        //EmptyStock() is called in FillStock()
+    }
+
     public IEnumerator FillStock(List<AugmentScript> augmentsInStock, int totalAugments = 3)
     {
         for(int i=0; i<totalAugments; i++)
@@ -138,11 +160,13 @@ public class AugmentPool : MonoBehaviour
         return augment;
     }
 
-    public void RandomizeAugmentStats(AugmentScript augment)
+    public void RandomizeAugmentStats(AugmentScript augment, bool skipListCheck = false)
     {
-        //Check if Augment is already listed
-        if(CheckIfListed(augment)) return;
+        //Check if Augment is already listed, this prevents listed duplicates from updating levels
+        // if(CheckIfListed(augment)) return;
+        if(CheckIfListed(augment) && !skipListCheck) return;
 
+        Debug.Log("Randomizing stats");
         //Can be called from other scripts if the Player wants to reroll the Level/stats
         int randLevel = RandomAugmentLevel();
         augment.UpdateLevel(randLevel); //Updates stats to Level

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -86,13 +86,14 @@ public class AugmentPool : MonoBehaviour
         // Debug.Log("AugLvl: " + chosenAugment.AugmentLevel + ", ShopLvl: " + augmentLevel);
         if(ownedAugments.Contains(chosenAugment))
         {
-            augmentInventory.RemoveAugment(chosenAugment);
+            augmentInventory.DuplicateAugment(chosenAugment);
         }
-        // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
-        SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);
-
-        augmentInventory.AddAugment(chosenAugment);
-        
+        else
+        {
+            // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
+            SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);
+            augmentInventory.AddAugment(chosenAugment);
+        }
         //Augment was chosen, move the remaining listed augments back to unowned
         //EmptyStock() is called in FillStock()
     }

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -97,28 +97,6 @@ public class AugmentPool : MonoBehaviour
         //EmptyStock() is called in FillStock()
     }
 
-    public void ChooseAugment(AugmentScript chosenAugment, bool randomLevel) //TODO: testing
-    {
-        //Check if chosenAugment is already owned, remove old and reset stats
-        // Debug.Log("AugLvl: " + chosenAugment.AugmentLevel + ", ShopLvl: " + augmentLevel);
-        if(ownedAugments.Contains(chosenAugment))
-        {
-            Debug.Log("Augment is already owned");
-            augmentInventory.RemoveAugment(chosenAugment);
-            
-        }
-        
-        // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
-        RandomizeAugmentStats(chosenAugment);
-
-        // SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);
-
-        augmentInventory.AddAugment(chosenAugment);
-        
-        //Augment was chosen, move the remaining listed augments back to unowned
-        //EmptyStock() is called in FillStock()
-    }
-
     public IEnumerator FillStock(List<AugmentScript> augmentsInStock, int totalAugments = 3)
     {
         for(int i=0; i<totalAugments; i++)
@@ -166,7 +144,6 @@ public class AugmentPool : MonoBehaviour
         // if(CheckIfListed(augment)) return;
         if(CheckIfListed(augment) && !skipListCheck) return;
 
-        Debug.Log("Randomizing stats");
         //Can be called from other scripts if the Player wants to reroll the Level/stats
         int randLevel = RandomAugmentLevel();
         augment.UpdateLevel(randLevel); //Updates stats to Level
@@ -195,6 +172,8 @@ public class AugmentPool : MonoBehaviour
     {
         int augmentLevel = 1; //1-5
         float rand = Random.Range(0f, 1.01f);
+
+        // Debug.Log("Random Level: " + rand);
         
         if(rand >= .50f) augmentLevel = 1; //- 50%
         else if(rand >= .20f) augmentLevel = 2; //- 30%

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -17,8 +17,8 @@ public class AugmentScript : MonoBehaviour
     public float buffedAmount;
     public float buffedAmountPercent;
     public int DebuffedStat;
-    public float debuffedAmount;
-    public float debuffedAmountPercent;
+    public float debuffedAmount; //TODO: might not use, just use a negative value for buffedAmount
+    public float debuffedAmountPercent; //TODO: might not use, just use a negative value for buffedAmount
     [Header("Icons")]
     [SerializeField] public Sprite Icon_Image;
 
@@ -26,6 +26,12 @@ public class AugmentScript : MonoBehaviour
     [SerializeField] public string Name;
     [Multiline(10)]
     [SerializeField] public string Description;
+
+    // Base amounts (before level stats)
+    [Header("Debugging")]
+    [SerializeField] private string baseDescription;
+    [SerializeField] private float baseBuffedAmount;
+    [SerializeField] private float baseBuffedAmountPercent;
 
 
     void Awake()
@@ -46,11 +52,14 @@ public class AugmentScript : MonoBehaviour
         if(augmentScrObj == null) { Debug.Log("No Augment Scriptable Object referenced!"); return; }
         Name = augmentScrObj.Name;
         Icon_Image = augmentScrObj.AugmentIcon;
-        Description = augmentScrObj.Description;
+        baseDescription = augmentScrObj.Description;
         BuffedStat = (int)augmentScrObj.BuffedStat;
         buffedAmount = augmentScrObj.StatIncrease;
         Debug.Log("Augment Stats loaded");
+        baseBuffedAmount = buffedAmount;
+        // baseBuffedAmountPercent = 
         // DebuffedStat = augmentScrObj. //TODO: might just use "modifiedStat", then use + or - for changes
+        UpdateDescription();
     }
 //
  
@@ -65,15 +74,30 @@ public class AugmentScript : MonoBehaviour
 #region Change Stats based on Level
     private void UpdateStatsToLevel()
     {
+        ResetStats();
+
         // if(AugmentLevel >= augmentScrObj.MaxUpgradeLevel) return;
         int scaledLevel = (AugmentLevel - 1);
         //Upgrade stats
         if(buffedAmount != 0) buffedAmount += scaledLevel;
-        if(buffedAmountPercent != 0f) buffedAmountPercent += scaledLevel * .02f;
+        if(buffedAmountPercent != 0f) { buffedAmountPercent += scaledLevel * .02f; Debug.Log("buffedAmountPercent not setup!");}
         if(debuffedAmount != 0) debuffedAmount -= scaledLevel;
         if(debuffedAmountPercent != 0f) debuffedAmountPercent += scaledLevel * .02f;
 
-        //TODO: update description
+        UpdateDescription();
+    }
+
+    private void UpdateDescription()
+    {
+        Description = buffedAmount.ToString() + " " + baseDescription;
+    }
+
+    private void ResetStats()
+    {
+        buffedAmount = baseBuffedAmount;
+        buffedAmountPercent = baseBuffedAmountPercent;
+        debuffedAmount = 0;
+        debuffedAmountPercent = 0;
     }
 
 #endregion

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -87,9 +87,14 @@ public class AugmentScript : MonoBehaviour
         UpdateDescription();
     }
 
-    private void UpdateDescription()
+    public void UpdateDescription(bool random = false)
     {
-        Description = buffedAmount.ToString() + " " + baseDescription;
+        if(augmentScrObj == null) return;
+        if(random) Description =  "+? " + baseDescription;
+        else{
+            if(buffedAmount > 0) Description = "+" + buffedAmount.ToString() + " " + baseDescription;
+            else Description = "-" + buffedAmount.ToString() + " " + baseDescription;
+        }
     }
 
     private void ResetStats()

--- a/_Augments/AugmentSelectMenu.cs
+++ b/_Augments/AugmentSelectMenu.cs
@@ -62,8 +62,6 @@ public class AugmentSelectMenu : MonoBehaviour
         //If refresh isn't allowed, disable the button, otherwise update the displayed Refresh Cost text
         if(!refreshAllowed) refreshButtonText.transform.parent.gameObject.SetActive(false);
         else if(refreshButtonText != null) refreshButtonText.text = refreshCost.ToString();
-
-        // if(augmentsInStock.Count == 3) UpdateDisplay(); //TODO:
     }
 
     void OnDisable()
@@ -128,12 +126,20 @@ public class AugmentSelectMenu : MonoBehaviour
         refreshingStockOverlay.SetActive(false);
     }
 
-    public void SelectAugment(AugmentScript augment)
+    public void SelectAugment(AugmentScript augment, bool randomizeLevel)
     {
         if(!allowInput) return;
         if(augmentInventory == null) augmentInventory = GameManager.Instance.AugmentInventory;
         int chosenIndex = augmentsInStock.IndexOf(augment);
-        pool.ChooseAugment(augment);
+
+        //Get Random level if it is a duplicate Augment
+        if(randomizeLevel)
+        {
+            pool.RandomizeAugmentStats(augment, true);
+            // pool.ChooseAugment(augment, true);
+            pool.ChooseAugment(augment); //TODO: testing if function needs override
+        }
+        else pool.ChooseAugment(augment); //Randomize augment before adding
 
         //Disable input for selecting Augments
         for(int i=0; i<totalAugments; i++) menuSlots[i].allowInput = false;

--- a/_Augments/AugmentSelectMenu.cs
+++ b/_Augments/AugmentSelectMenu.cs
@@ -133,13 +133,9 @@ public class AugmentSelectMenu : MonoBehaviour
         int chosenIndex = augmentsInStock.IndexOf(augment);
 
         //Get Random level if it is a duplicate Augment
-        if(randomizeLevel)
-        {
-            pool.RandomizeAugmentStats(augment, true);
-            // pool.ChooseAugment(augment, true);
-            pool.ChooseAugment(augment); //TODO: testing if function needs override
-        }
-        else pool.ChooseAugment(augment); //Randomize augment before adding
+        if(randomizeLevel) pool.RandomizeAugmentStats(augment, true);
+        
+        pool.ChooseAugment(augment); //Randomize augment before adding
 
         //Disable input for selecting Augments
         for(int i=0; i<totalAugments; i++) menuSlots[i].allowInput = false;

--- a/_Player Scripts/AugmentInventory.cs
+++ b/_Player Scripts/AugmentInventory.cs
@@ -114,6 +114,12 @@ public class AugmentInventory : MonoBehaviour
             ApplyAugmentStats(heldAugments[i]);
         }
 
+        //Update Augment slot displays
+        for(int i=0; i<heldAugments.Count; i++)
+        {
+            augmentInventoryDisplay.AugmentSlots[i].RefreshDisplayInfo();
+        }
+
         ModifyPlayerStats();
         
         //Update health
@@ -121,7 +127,22 @@ public class AugmentInventory : MonoBehaviour
         else combat.currentHP = tempPlayerHP;
 
         combat.HealPlayer(0, false);
+
+        // StartCoroutine(DelayUpdateStats(tempPlayerHP));
     }
+
+    // IEnumerator DelayUpdateStats(float tempPlayerHP)
+    // {
+    //     yield return new WaitForSecondsRealtime(.1f);
+
+    //     ModifyPlayerStats();
+        
+    //     //Update health
+    //     if(combat.currentHP < tempPlayerHP) combat.currentHP = combat.maxHP;
+    //     else combat.currentHP = tempPlayerHP;
+
+    //     combat.HealPlayer(0, false);
+    // }
 
     public void AddAugment(AugmentScript augment)
     {
@@ -134,7 +155,7 @@ public class AugmentInventory : MonoBehaviour
     {
         heldAugments.Remove(augment);
         ResetModifiedStats();
-        //TODO: need to return to pool
+        //TODO: need to return to pool //?
         UpdateAugments();
     }
 

--- a/_Player Scripts/AugmentInventory.cs
+++ b/_Player Scripts/AugmentInventory.cs
@@ -107,7 +107,7 @@ public class AugmentInventory : MonoBehaviour
         float tempPlayerHP = combat.currentHP; //Store Player HP in case of max health being reduced
         
         //Reset Player stats before re-applying stat boosts
-        ResetPlayerStats();
+        ResetPlayerStats(); //Might not be needed if RemoveAugmentStats isn't bugged
 
         for(int i=0; i<heldAugments.Count; i++)
         {
@@ -154,15 +154,16 @@ public class AugmentInventory : MonoBehaviour
     public void RemoveAugment(AugmentScript augment)
     {
         heldAugments.Remove(augment);
+        RemoveAugmentStats(augment);
         ResetModifiedStats();
-        //TODO: need to return to pool //?
+        
         UpdateAugments();
     }
 
     private void ApplyAugmentStats(AugmentScript augment)
     {
         int statIndex = (int)augment.BuffedStat; //TODO: check typecast
-        // int statIndex = augment.DebuffedStat;
+        // augment.DebuffedStat not needed, just set as negative value
 
         //TODO:
         // Either call the code from the augment directly, or do it here with switch cases?
@@ -173,6 +174,22 @@ public class AugmentInventory : MonoBehaviour
             case 2: modified_MoveSpeed += augment.buffedAmount; break;
             case 3: modified_AttackDamage += augment.buffedAmount; break;
             case 4: modified_AttackSpeed += augment.buffedAmount; break;
+            //case 5: crit chance?
+            default: break;
+        }
+    }
+
+    private void RemoveAugmentStats(AugmentScript augment)
+    {
+        int statIndex = (int)augment.BuffedStat;
+
+        switch(statIndex)
+        {
+            case 0: modified_MaxHP -= augment.buffedAmount; break;
+            case 1: modified_Defense -= augment.buffedAmount; break;
+            case 2: modified_MoveSpeed -= augment.buffedAmount; break;
+            case 3: modified_AttackDamage -= augment.buffedAmount; break;
+            case 4: modified_AttackSpeed -= augment.buffedAmount; break;
             //case 5: crit chance?
             default: break;
         }

--- a/_Player Scripts/AugmentInventory.cs
+++ b/_Player Scripts/AugmentInventory.cs
@@ -108,6 +108,7 @@ public class AugmentInventory : MonoBehaviour
         
         //Reset Player stats before re-applying stat boosts
         ResetPlayerStats(); //Might not be needed if RemoveAugmentStats isn't bugged
+        ResetModifiedStats();
 
         for(int i=0; i<heldAugments.Count; i++)
         {
@@ -157,6 +158,14 @@ public class AugmentInventory : MonoBehaviour
         RemoveAugmentStats(augment);
         ResetModifiedStats();
         
+        UpdateAugments();
+    }
+
+    public void DuplicateAugment(AugmentScript augment)
+    {
+        RemoveAugmentStats(augment);
+        // ResetModifiedStats();
+        // ApplyAugmentStats(augment);
         UpdateAugments();
     }
 


### PR DESCRIPTION
### Augment Updates
- Duplicate Augments that are already held by the Player will display "Lv ??"
  - Purchasing the augment will replace the owned augment with a new copy with a random level
- Augment stats are updated in the AugmentInventory
- Description now updates with level-based stats
  - Ex: +2 Attack or +4 Attack, random augments display +? Attack

**Misc**
  - Added a RemoveAugment() function to remove a specific Augment's stats from modified stats
  - Fixed issues with augments not properly resetting stats when replacing duplicates