### PR TITLE
Upgrade Shop, bug fixes

### DIFF
--- a/CastExplosion.cs
+++ b/CastExplosion.cs
@@ -12,6 +12,9 @@ public class CastExplosion : MonoBehaviour
     [SerializeField] private Animator animExplosion;
     [SerializeField] float explosionDuration = 0.583f;
     [SerializeField] int explosionHashedInt;
+    [Space(10)]
+    [SerializeField] float animDelay = 0;
+    [Space(10)]
 
     [Header("Adjustable Variables")]
     [SerializeField] int screenshakeIntensity = 1;
@@ -67,8 +70,10 @@ public class CastExplosion : MonoBehaviour
             yield return new WaitForSeconds(chargeDuration);
         }
 
-        CheckHit();
         animExplosion.Play(explosionHashedInt);//"Explosion");
+        yield return new WaitForSeconds(animDelay);
+        CheckHit();
+
         ScreenShakeListener.Instance.Shake(screenshakeIntensity);
         yield return new WaitForSeconds(explosionDuration);
         

--- a/ShopController.cs
+++ b/ShopController.cs
@@ -14,6 +14,11 @@ public class ShopController : MonoBehaviour
     private bool canTakeInput;
     public bool oneTimePurchaseDone;
 
+    [Space(20)]
+    [Header("= Upgrade Shop Only =")]
+    [SerializeField] bool upgradeShop = false;
+    [SerializeField] GameObject needMoreAugmentsMessage;
+
     void Start()
     {
         //augmentPool reference for cross-scene ref
@@ -22,6 +27,7 @@ public class ShopController : MonoBehaviour
         ToggleText(false);
         canTakeInput = false;
         OpenShop(false);
+        ToggleShopMessage(false);
     }
 
     void Update()
@@ -60,8 +66,26 @@ public class ShopController : MonoBehaviour
     {
         if(oneTimePurchaseDone && !DEBUGGING) return;
         if(!collider.CompareTag("Player")) return;
-        ToggleText(true);
-        canTakeInput = true;
+
+        if(upgradeShop) //Upgrade shop needs 3 augments
+        {
+            if(CheckPlayerInsufficientAugments())
+            {
+                ToggleText(false);
+                canTakeInput = false;
+                ToggleShopMessage(true);
+            }
+            else
+            {
+                ToggleText(true);
+                canTakeInput = true;
+                ToggleShopMessage(false);
+            }
+        }else{ //Normal Shop
+            ToggleText(true);
+            canTakeInput = true;
+            ToggleShopMessage(false);
+        }
     }
 
     void OnTriggerExit2D(Collider2D collider)
@@ -69,5 +93,18 @@ public class ShopController : MonoBehaviour
         if(!collider.CompareTag("Player")) return;
         ToggleText(false);
         canTakeInput = false;
+        ToggleShopMessage(false);
+    }
+
+    void ToggleShopMessage(bool toggle)
+    {
+        if(needMoreAugmentsMessage == null) return;
+        needMoreAugmentsMessage.SetActive(toggle);
+    }
+
+    bool CheckPlayerInsufficientAugments()
+    {
+        int totalOwnedAugments = augmentPool.ownedAugments.Count;
+        return totalOwnedAugments < 3;
     }
 }

--- a/ShopController.cs
+++ b/ShopController.cs
@@ -11,7 +11,7 @@ public class ShopController : MonoBehaviour
     [SerializeField] GameObject inputPrompt;
     [SerializeField] GameObject shopWindow;
     public AugmentPool augmentPool;
-    private bool canTakeInput;
+    [SerializeField] private bool canTakeInput;
     public bool oneTimePurchaseDone;
 
     [Space(20)]

--- a/_Assemblies.meta
+++ b/_Assemblies.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31ab08661b29f5f4c8c1da9dfeb87761
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/Augment.cs
+++ b/_Augments/Augment.cs
@@ -31,7 +31,7 @@ public class Augment : ScriptableObject
     [Header("= Buffed Stats =")]
     public float StatIncrease;
     public float StatIncreasePerLevel;
-    public enum _IncreaseType { Flat, Percent };
+    public enum _IncreaseType { Flat, Percent, Misc };
     public _IncreaseType IncreaseType;
     public enum _BuffedStat { 
         Health, Defense, Move_Speed, 
@@ -49,6 +49,13 @@ public class Augment : ScriptableObject
         AttackDamage, AttackSpeed, 
         CritChance, CritMultiplier };
     public _DebuffedStat DebuffedStat;
+
+    // [Space(10)]
+    // [Header("== Conditional Augments (Only AugmentType != 0) ==")]
+    // public float conditionalBuffAmount;
+
+
+
 
     //Example:
         //FlatIncrease: 2

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -39,6 +39,7 @@ public class AugmentDisplay : MonoBehaviour
     
     [Header("Duplicate")]
     [SerializeField] private bool randomizeLevel = false;
+    [SerializeField] public bool upgradeShop = false;
 
     void Start()
     {
@@ -87,6 +88,7 @@ public class AugmentDisplay : MonoBehaviour
 
     IEnumerator RevealAugment()
     {
+        allowInput = false;
         // yield return new WaitForSecondsRealtime(.2f);
         //TODO: start animation here
         // yield return new WaitForSecondsRealtime(.2f); //Animation time
@@ -95,17 +97,38 @@ public class AugmentDisplay : MonoBehaviour
         allowInput = true;
         if(augmentScript != null && selectMenu != null)
         {
-            if(selectMenu.IsOwnedAndListed(augmentScript) && selectMenu.IsMaxLevel(augmentScript))
+            if(selectMenu.IsOwnedAndListed(augmentScript))
             {
-                //Overlay toggled if Augment is owned and listed, and is maxLevel
-                ToggleOverlay(true, true);
-                allowInput = false;
+                if(selectMenu.IsMaxLevel(augmentScript))
+                {
+                    //Block purchase if max level
+                    ToggleOverlay(true, true);
+                    allowInput = false;
+                }
+                else
+                {
+                    //Only allow duplicate purchase if Upgrade Shop
+                    allowInput = upgradeShop;
+                    if(upgradeShop){
+                        ToggleOverlay(false);
+                    }else{
+                        ToggleOverlay(true, true);
+                    }
+                }
             }
-            else
-            {
-                ToggleOverlay(false);
-                allowInput = true;
-            }
+            
+
+            // if(selectMenu.IsOwnedAndListed(augmentScript) && selectMenu.IsMaxLevel(augmentScript))
+            // {
+            //     //Overlay toggled if Augment is owned and listed, and is maxLevel
+            //     ToggleOverlay(true, true);
+            //     allowInput = false;
+            // }
+            // else
+            // {
+            //     ToggleOverlay(false);
+            //     allowInput = true;
+            // }
         }
     }
 

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -112,7 +112,7 @@ public class AugmentDisplay : MonoBehaviour
                     if(upgradeShop){
                         ToggleOverlay(false);
                     }else{
-                        ToggleOverlay(true, true);
+                        ToggleOverlay(true, false);
                     }
                 }
             }
@@ -154,40 +154,65 @@ public class AugmentDisplay : MonoBehaviour
         AugmentIcon_Image.sprite = augmentScript.Icon_Image;
         DisplayDescription.text = augmentScript.Description;
 
-        bool duplicate;
+        bool isOwned;
         if(augmentScript != null && selectMenu != null)
         {
-            if(selectMenu.IsOwned(augmentScript)) duplicate = true;
-            else duplicate = false;
+            if(selectMenu.IsOwned(augmentScript)) isOwned = true;
+            else isOwned = false;
 
-            bool overlayToggle = false; //TODO: or true?
-            bool maxLevel = false;
+            bool toggleOverlay; //TODO: or true?
+            bool isMaxLevel;
 
-            //Check for Duplicate augments not at Max level | no overlay
-            if(duplicate && !selectMenu.IsMaxLevel(augmentScript))
-            {
-                DisplayLevel.text = "Lv ??";
-                
-                if(!inInventory) augmentScript.UpdateDescription(true);
-                else augmentScript.UpdateDescription();
-
-                if(ownedText != null) ownedText.SetActive(true);
-                randomizeLevel = true;
-                overlayToggle = false;
-                maxLevel = true;
-            }
-            else //Augment is not a Duplicate, or is Max Level | no overlay
-            {
-                DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
-                augmentScript.UpdateDescription();
-
-                maxLevel = selectMenu.IsMaxLevel(augmentScript);
-                if(ownedText != null) ownedText.SetActive(false);
-                randomizeLevel = false;
-                overlayToggle = false;
-            }
             //Overlay toggled if duplicate AND maxLevel
-            ToggleOverlay(overlayToggle, maxLevel); //maxLevel false | "Purchased" overlay
+
+            if(upgradeShop)
+            {
+                if(selectMenu.IsMaxLevel(augmentScript))
+                {
+                    augmentScript.UpdateDescription();
+                    randomizeLevel = false;
+                    toggleOverlay = true;
+                    isMaxLevel = true;
+                }
+                else
+                {
+                    DisplayLevel.text = "Lv ??";
+                    augmentScript.UpdateDescription(true);
+
+                    if(ownedText != null) ownedText.SetActive(true);
+                    randomizeLevel = true;
+                    toggleOverlay = false;
+                    isMaxLevel = false;
+                }
+            }
+            else
+            {
+                // DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
+
+                if(selectMenu.IsMaxLevel(augmentScript)) //max Level no upgrade
+                {
+                    augmentScript.UpdateDescription();
+                    randomizeLevel = false;
+
+                    if(isOwned) toggleOverlay = true;
+                    else toggleOverlay = false;
+
+                    isMaxLevel = true;
+                }
+                else //Not Max Level, not in upgrade shop
+                {
+                    DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
+                    augmentScript.UpdateDescription();
+
+                    isMaxLevel = false;
+                    if(ownedText != null) ownedText.SetActive(false);
+                    randomizeLevel = false;
+                    toggleOverlay = false;
+                }
+            }
+
+
+            ToggleOverlay(toggleOverlay, isMaxLevel); //maxLevel false | "Purchased" overlay
         }
         else DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
         

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -51,6 +51,21 @@ public class AugmentPool : MonoBehaviour
         return newAugment;
     }
 
+    public AugmentScript GetOwnedAugment()
+    {
+        //Only used with upgradeShop
+        // AugmentScript augmentFromPool;
+        if(ownedAugments.Count < 3)
+        {
+            Debug.Log("Not enough owned augments!");
+            return null;
+        }
+
+        int randIdx = Random.Range(0, ownedAugments.Count);
+
+        return ownedAugments[randIdx];
+    }
+
     public AugmentScript GetAugmentFromPool()//List<AugmentScript> augmentList)
     {
         //Add augments at random index
@@ -101,16 +116,21 @@ public class AugmentPool : MonoBehaviour
         //EmptyStock() is called in FillStock()
     }
 
-    public IEnumerator FillStock(List<AugmentScript> augmentsInStock, int totalAugments = 3)
+    public IEnumerator FillStock(List<AugmentScript> augmentsInStock, bool upgradeShop = false, int totalAugments = 3)
     {
         for(int i=0; i<totalAugments; i++)
         {
-            AugmentScript currAugment = GetAugmentFromPool();
+            AugmentScript currAugment;
+
+            //Upgrade shop only pulls from ownedAugments pool
+            if(upgradeShop) currAugment = GetOwnedAugment();
+            else currAugment = GetAugmentFromPool();
             
             augmentsInStock.Add(currAugment); //AugmentSelectMenu //TODO:
             
             yield return new WaitForSecondsRealtime(.01f);
-            StockShop(currAugment); //Pool list //TODO: this should work
+
+            StockShop(currAugment); //Pool list
         }
         yield return new WaitForSecondsRealtime(.01f);
         EmptyStock();
@@ -119,9 +139,10 @@ public class AugmentPool : MonoBehaviour
     public void StockShop(AugmentScript augment, bool sellingDuplicates = true)
     {
         //Move augment from unownedPool into shopListed
-        //This prevents duplicates
+        //'sellingDuplicates' allow multiple shops to list the same unowned Augment
         if(sellingDuplicates) SwapAugmentList(augment, GetAugmentList(augment), listedAugmentsTEMP);
         else SwapAugmentList(augment, ownedAugments, listedAugmentsTEMP);
+        
     }
 
     private List<AugmentScript> GetAugmentList(AugmentScript augment)
@@ -157,29 +178,48 @@ public class AugmentPool : MonoBehaviour
     private int RandomAugmentTier()
     {
         int augmentTier; //1-5
-        float rand = Random.Range(0f, 1.01f); //additional 1% higher
-        
-        // if(rand >= .50f) augmentTier = 0; //Common - 50%
-        // else if(rand >= .20f) augmentTier = 1; //Rare - 30%
-        // else if(rand >= .04f) augmentTier = 2; //Epic - 16%
-        // else if(rand >= .01f) augmentTier = 3; //Legendary - 3%
-        // else{ //Overcharged or Unstable - 1%
-        //     rand = Random.Range(0f, 1.0f);
-        //     if(rand >= .5f) augmentTier = 4;
-        //     else augmentTier = 5;
+        // float rand = Random.Range(0f, 1.01f); //additional 1% higher
+
+        // float rand = Random.value;
+        float rand = Random.value;
+
+        ///////////////////// Testing drop rates ////////////////////////
+
+        // int t5Count=0, t4Count=0, t3Count=0, t2Count=0, t1Count=0;
+
+        // for(int i=0; i<100; i++)
+        // {
+        //     rand = Random.value;
+        //     if(rand <= .02f){
+        //     //Overcharged or Unstable - 1%
+        //     // rand = Random.Range(0f, 1.0f);
+        //         t5Count++;
+        //     } 
+        //     else if(rand <= .08f) { t4Count++; } //Legendary - 3%
+        //     else if(rand <= .25f) { t3Count++; }//Epic - 16%
+        //     else if(rand <= .55f) { t2Count++;}//Rare - 30%
+        //     else { t1Count++; }//Common - 50%
         // }
-        //
         
-        if(rand <= .01f){
-            //Overcharged or Unstable - 1%
-            rand = Random.Range(0f, 1.0f);
+        // Debug.Log("T1: " + t1Count);
+        // Debug.Log("T2: " + t2Count);
+        // Debug.Log("T3: " + t3Count);
+        // Debug.Log("T4: " + t4Count);
+        // Debug.Log("T5: " + t5Count);
+
+        /////////////////////////////////////////////////////////
+
+
+        if(rand <= .02f){ //Overcharged or Unstable - 2%
+            // rand = Random.Range(0f, 1.0f);
+            rand = Random.value;
             if(rand < .5f) augmentTier = 4; 
             else augmentTier = 5; 
         }
-        else if(rand <= .03f) augmentTier = 3; //Legendary - 3%
-        else if(rand <= .16f) augmentTier = 2; //Epic - 16%
-        else if(rand <= .3f) augmentTier = 1; //Rare - 30%
-        else augmentTier = 0; //Common - 50%
+        else if(rand <= .08f) augmentTier = 3; //Legendary - 6%
+        else if(rand <= .25f) augmentTier = 2; //Epic - 17%
+        else if(rand <= .55f) augmentTier = 1; //Rare - 30%
+        else augmentTier = 0; //Common - 45%
 
         return augmentTier;
     }
@@ -209,6 +249,7 @@ public class AugmentPool : MonoBehaviour
 
     public void EmptyStock()
     {
+        // if(listedAugmentsTEMP.Count == 0) return;
         StartCoroutine(EmptyStockCO());
     }
 

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -51,7 +51,7 @@ public class AugmentPool : MonoBehaviour
         return newAugment;
     }
 
-    public AugmentScript GetOwnedAugment()
+    public AugmentScript GetDuplicateAugment() //Duplicate
     {
         //Only used with upgradeShop
         // AugmentScript augmentFromPool;
@@ -62,6 +62,10 @@ public class AugmentPool : MonoBehaviour
         }
 
         int randIdx = Random.Range(0, ownedAugments.Count);
+        while(listedAugmentsTEMP.Contains(ownedAugments[randIdx]))
+        {
+            randIdx = Random.Range(0, ownedAugments.Count);
+        }
 
         return ownedAugments[randIdx];
     }
@@ -123,7 +127,7 @@ public class AugmentPool : MonoBehaviour
             AugmentScript currAugment;
 
             //Upgrade shop only pulls from ownedAugments pool
-            if(upgradeShop) currAugment = GetOwnedAugment();
+            if(upgradeShop) currAugment = GetDuplicateAugment();
             else currAugment = GetAugmentFromPool();
             
             augmentsInStock.Add(currAugment); //AugmentSelectMenu //TODO:
@@ -216,18 +220,19 @@ public class AugmentPool : MonoBehaviour
             if(rand < .5f) augmentTier = 4; 
             else augmentTier = 5; 
         }
-        else if(rand <= .08f) augmentTier = 3; //Legendary - 6%
-        else if(rand <= .25f) augmentTier = 2; //Epic - 17%
-        else if(rand <= .55f) augmentTier = 1; //Rare - 30%
-        else augmentTier = 0; //Common - 45%
+        else if(rand <= .06f) augmentTier = 3; //Legendary - 4%
+        else if(rand <= .20f) augmentTier = 2; //Epic - 14%
+        else if(rand <= .50f) augmentTier = 1; //Rare - 30%
+        else augmentTier = 0; //Common - 50%
 
         return augmentTier;
     }
 
     private int RandomAugmentLevel()
     {
-        int augmentLevel = 1; //1-5
-        float rand = Random.Range(0f, 1.0f);
+        int augmentLevel; //1-5
+        // float rand = Random.Range(0f, 1.0f);
+        float rand = Random.value;
 
         // Debug.Log("Random Level: " + rand);
         
@@ -237,11 +242,11 @@ public class AugmentPool : MonoBehaviour
         // else if(rand >= .01f) augmentLevel = 4; //- 3%
         // else augmentLevel = 5; //- 1%
         //
-        if(rand <= .01f) augmentLevel = 5; //- 1%
-        else if(rand <= .03f) augmentLevel = 4; //- 3%
-        else if(rand <= .16f) augmentLevel = 3; //- 16%
-        else if(rand <= .30f) augmentLevel = 2; //- 30%
-        else if(rand <= .5f) augmentLevel = 1; //- 50%
+        if(rand <= .02f) augmentLevel = 5; //- 2%
+        else if(rand <= .09f) augmentLevel = 4; //- 7%
+        else if(rand <= .25f) augmentLevel = 3; //- 16%
+        else if(rand <= .55f) augmentLevel = 2; //- 30%
+        else augmentLevel = 1; //- 50%
 
         return augmentLevel;
     }

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using UnityEngine.TextCore.Text;
 
 public class AugmentScript : MonoBehaviour
 {
@@ -24,6 +25,11 @@ public class AugmentScript : MonoBehaviour
     public int DebuffedStat;
     public float debuffedAmount; //TODO: might not use, just use a negative value for buffedAmount
     public float debuffedAmountPercent; //TODO: might not use, just use a negative value for buffedAmount
+
+    // [Header("Conditional Stats")]
+    // public float conditionalBuffedAmount;
+    // public float conditionalBuffedAmountPercent;
+
     [Header("Icons")]
     [SerializeField] public Sprite Icon_Image;
 
@@ -58,6 +64,7 @@ public class AugmentScript : MonoBehaviour
         Name = augmentScrObj.Name;
         Icon_Image = augmentScrObj.AugmentIcon;
 
+        //
         baseDescription = augmentScrObj.Description;
         AugmentType = (int)augmentScrObj.AugmentType;
         ConditionalAugmentScript = GetComponent<Base_ConditionalAugments>();
@@ -121,7 +128,7 @@ public class AugmentScript : MonoBehaviour
     {
         if(augmentScrObj == null) return;
 
-        string divider;
+        string divider = "";;
         float stat;
         string statType = "";// = BuffedStatName;
         //Separates Stat names if a space is needed
@@ -130,15 +137,21 @@ public class AugmentScript : MonoBehaviour
             statType += " ";
         }
 
-        if(increaseType == 0)
+        //Display if stat is a flat damage boost or percent
+        if(increaseType == 0) //[0] Flat
         {
             stat = buffedAmount;
-            divider = " "; //It's this or another if()
         }
-        else
+        else if(increaseType == 2) //[2] Conditional
+        {
+            //Note: this is used by augments that only have a conditional
+            stat = buffedAmount;
+            // stat = conditionalBuffedAmount;
+        }
+        else //[1] Percent
         {
             stat = buffedAmountPercent;
-            divider = "% ";
+            divider = "%";
         }
         
         //Example:
@@ -146,14 +159,14 @@ public class AugmentScript : MonoBehaviour
         // +5 Attack
         // +10% Attack Speed
 
-        Description = baseDescription + "<br>---<br>"; //New line, divider for stat display
-        if(random) Description =  "+? " + statType;
-        else{
-            if(stat > 0) Description += "+" + stat.ToString() + divider + statType;
-            else if(stat < 0) Description += "-" + stat.ToString() + divider + statType;
+        if(augmentScrObj != null)
+        {
+            string buffedDesc = stat.ToString() + divider;
+            Description = baseDescription.Replace('#'.ToString(), buffedDesc);
+
+            // string conditionalDesc = conditionalBuffedAmount.ToString();
+            // Description = baseDescription.Replace('@'.ToString(), conditionalDesc);
         }
-    
-        //
     }
 
     private void ResetStats()

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -161,9 +161,14 @@ public class AugmentScript : MonoBehaviour
 
         if(augmentScrObj != null)
         {
-            string buffedDesc = stat.ToString() + divider;
-            Description = baseDescription.Replace('#'.ToString(), buffedDesc);
-
+            if(random)
+            {
+                string buffedDesc = "?" + divider;
+                Description = baseDescription.Replace('#'.ToString(), buffedDesc);
+            }else{
+                string buffedDesc = stat.ToString() + divider;
+                Description = baseDescription.Replace('#'.ToString(), buffedDesc);
+            }
             // string conditionalDesc = conditionalBuffedAmount.ToString();
             // Description = baseDescription.Replace('@'.ToString(), conditionalDesc);
         }

--- a/_Augments/AugmentSelectMenu.cs
+++ b/_Augments/AugmentSelectMenu.cs
@@ -71,6 +71,7 @@ public class AugmentSelectMenu : MonoBehaviour
     void OnDisable()
     {
         GameManager.Instance.shopOpen = false;
+        GameManager.Instance.rewardOpen = false;
         GameManager.Instance.Pause.Resume();
     }
 

--- a/_Augments/AugmentSelectMenu.cs
+++ b/_Augments/AugmentSelectMenu.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
+using System.Net.Http.Headers;
 
 public class AugmentSelectMenu : MonoBehaviour
 {
@@ -17,7 +18,8 @@ public class AugmentSelectMenu : MonoBehaviour
 
     [Header("SHOP or REWARD")]
     [SerializeField] public bool isShop = false;
-    [SerializeField] public bool duplicates = false;
+    // [SerializeField] public bool duplicates = false;
+    [SerializeField] public bool upgradeShop = false;
 
     [Header("Refresh Cost")]
     [SerializeField] public bool refreshAllowed = false;
@@ -107,7 +109,7 @@ public class AugmentSelectMenu : MonoBehaviour
 
         augmentsInStock.Clear();
 
-        yield return pool.FillStock(augmentsInStock);
+        yield return pool.FillStock(augmentsInStock, upgradeShop);
 
         for(int i=0; i<totalAugments; i++)
         {
@@ -171,6 +173,7 @@ public class AugmentSelectMenu : MonoBehaviour
             var currAugSlot = menuSlots[i].GetComponent<AugmentDisplay>();
 
             currAugSlot.alwaysDisplay = isShop;
+            currAugSlot.upgradeShop = upgradeShop; //Toggle duplicate purchases
             currAugSlot.augmentScript = augmentsInStock[i];
 
             if(isShop)

--- a/_Augments/Conditional/CA_AreaOfEffect_Local.cs
+++ b/_Augments/Conditional/CA_AreaOfEffect_Local.cs
@@ -15,7 +15,7 @@ public class CA_AreaOfEffect_Local : Base_ConditionalAugments
     protected override void Start()
     {
         base.Start();
-        attackPoint = GameManager.Instance.PlayerTargetOffset;
+        attackPoint = GameManager.Instance.playerTargetOffset;
     }
 
     protected override void Activate()

--- a/_Augments/Conditional/CA_Recuperation.cs
+++ b/_Augments/Conditional/CA_Recuperation.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CA_Recuperation : Base_ConditionalAugments
+{
+    [Space(20)]
+    [Header("Recuperation (set to buffedAmount)")]
+    [SerializeField] float healAmount = 4;
+
+    protected override void Start()
+    {
+        base.Start();
+        healAmount = augmentScript.buffedAmount;
+    }
+
+    protected override void Activate()
+    {
+        // base.Activate();
+        playerCombat.HealPlayer(healAmount);
+    }
+}

--- a/_Augments/Conditional/CA_Recuperation.cs.meta
+++ b/_Augments/Conditional/CA_Recuperation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45dc9c87096d87c48a2676722fff8ac2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Enemy Scripts/Base_BossCombat.cs
+++ b/_Enemy Scripts/Base_BossCombat.cs
@@ -59,6 +59,7 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
     [SerializeField] protected float currentHP;
     [SerializeField] protected float defense = 0;
     [SerializeField] protected int totalXPOrbs = 20;
+    [SerializeField] protected int totalHealOrbs = 10;
     
     [Header("--- Attack ---")]
     [SerializeField] public float[] attackDamage;
@@ -371,7 +372,7 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
     }
 
 #region Health Threshold and Phases
-    protected void HealthPhaseCheck() //Determine number of combo attacks and frequency
+    protected virtual void HealthPhaseCheck() //Determine number of combo attacks and frequency
     {
         //HP is at the last Phase, no need to update
         if(currentPhase == healthPhase.Length-1) return;
@@ -388,7 +389,7 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         attackEndDelay = 0.1f; //If no delay, attackSpeed delay still applies
     }
 
-    IEnumerator ChangePhase()
+    protected IEnumerator ChangePhase()
     {
         changingPhase = true;
         //Stop Attack and AttackEnd Coroutines

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -12,6 +12,7 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
 
     [Header("References/Setup")]
     public LayerMask playerLayer;
+    [SerializeField] Transform playerTransform;
     [SerializeField] protected Transform attackPoint;
     [SerializeField] protected Transform textPopupOffset;
     [SerializeField] public Transform hitEffectsOffset;
@@ -140,6 +141,7 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         //Must be in Start(), because of player scene loading.
         //Awake() might work during actual build with player scene always being active before enemy scenes.
         enemyStageManager = transform.parent.parent.GetComponent<EnemyStageManager>();
+        playerTransform = GameManager.Instance.playerTransform;
     }
 
     protected virtual void OnEnable()

--- a/_Enemy Scripts/Base_EnemyController.cs
+++ b/_Enemy Scripts/Base_EnemyController.cs
@@ -9,7 +9,7 @@ public class Base_EnemyController : MonoBehaviour
     public Base_EnemyCombat combat;
     public bool isRangedAttack = false;
     [SerializeField] private float CODurationLower = .2f, CODurationUpper = .8f;
-    
+    [SerializeField] Transform playerTransform;
 
     [Header("=== Raycasts Reference ===")]
     [SerializeField] public Base_EnemyRaycast raycast;
@@ -24,14 +24,16 @@ public class Base_EnemyController : MonoBehaviour
     Coroutine PatrolCO;
     Coroutine LandingCO;
 
-    private void Awake()
+    protected virtual void Awake()
     {
         if(movement == null) movement = GetComponent<Base_EnemyMovement>();
         if(combat == null) combat = GetComponent<Base_EnemyCombat>();
     }
 
-    private void Start()
+    protected virtual void Start()
     {
+        playerTransform = GameManager.Instance.playerTransform;
+
         bool startDir = (Random.value > 0.5f);
         // movement.MoveRight(startDir);
         StartIdle(.3f, false);
@@ -76,9 +78,11 @@ public class Base_EnemyController : MonoBehaviour
 
     void PlayerToRightCheck()
     {
+        combat.playerToRight = playerTransform.position.x > transform.position.x;
+
         //Only update if the player is actively being detected
-        if(raycast.playerDetectFront || raycast.playerDetectBack)
-            combat.playerToRight = raycast.playerToRight;
+        // if(raycast.playerDetectFront || raycast.playerDetectBack)
+        //     combat.playerToRight = raycast.playerToRight;
     }
 
     void AttackCheckClose()

--- a/_Enemy Scripts/Base_EnemyPlayerDetect.cs
+++ b/_Enemy Scripts/Base_EnemyPlayerDetect.cs
@@ -59,12 +59,12 @@ public class Base_EnemyPlayerDetect : MonoBehaviour
         if (groundCheck == null) groundCheck = transform.Find("groundCheck").transform;
 
         updatePlatform = true;
-        if(player == null) player = GameManager.Instance.Player;
+        if(player == null) player = GameManager.Instance.playerTransform;
     }
 
     void OnEnable()
     {
-        if(player == null) player = GameManager.Instance.Player;
+        if(player == null) player = GameManager.Instance.playerTransform;
     }
 
     void Update()

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.Mathematics;
 using UnityEngine;
 
 public class ColossalBoss_EnemyCombat : Base_BossCombat
@@ -424,7 +425,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
     }
 
 //Attack[4]: 
-    IEnumerator ChargeUp(int iterations = 3)
+    IEnumerator ChargeUp(int iterations = 2)
     {
         isAttacking = true;
 
@@ -557,7 +558,30 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
     }
 
 #endregion
+    protected override void HealthPhaseCheck()
+    {
 
+        //HP is at the last Phase, no need to update
+        if(currentPhase == healthPhase.Length-1) return;
+        
+        //Checking if health reaches the next phase threshold
+        float nextHealthThreshold = healthPhase[currentPhase+1];
+        if(currentHP <= nextHealthThreshold)
+        {
+            //Change to next Phase
+            if(changingPhase) return;
+            currentPhase++;
+            //If flying, drop to ground
+            if(canFly)
+            {
+                canFly = false;
+                movement.rb.gravityScale = originalScale;
+                movement.rb.drag = originalDrag;
+            } 
+            StartCoroutine(ChangePhase());
+        }
+        attackEndDelay = 0.1f; //If no delay, attackSpeed delay still applies
+    }
 
     protected override void Die()
     {
@@ -603,5 +627,6 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
         ScreenShakeListener.Instance.Shake(3);
         InstantiateManager.Instance.HitEffects.ShowKillEffect(offset);
         InstantiateManager.Instance.XPOrbs.SpawnOrbs(offset, totalXPOrbs);
+        InstantiateManager.Instance.HealOrbs.SpawnOrbs(offset, totalHealOrbs);
     }
 }

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -545,7 +545,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
     private Vector3 GetPlayerPosX()
     {
         //Get Player position and cast explosion for Initial explosion
-        float playerX = GameManager.Instance.Player.position.x;
+        float playerX = GameManager.Instance.playerTransform.position.x;
         Vector3 castPos = new Vector3(playerX, initialGroundOffset.y, 0);
         return castPos;
     }

--- a/_Enemy Scripts/OrbController.cs
+++ b/_Enemy Scripts/OrbController.cs
@@ -55,7 +55,7 @@ public class OrbController : MonoBehaviour
 
     private void FixedUpdate()
     {
-        if (!findPlayer) return;
+        if (!findPlayer || hitDone) return;
 
         orbSpeed *= 1.08f;
         var step = orbSpeed * Time.deltaTime;
@@ -86,11 +86,20 @@ public class OrbController : MonoBehaviour
     {
         //Check to make sure hits aren't registered multiple times on collision
         if (hitDone) return;
-        hitDone = true;
+        // hitDone = true;
+
+        Invoke("DisableVelocity", .25f);
+
         inventory.UpdateGold(1); //GiveXP
         animator.Play("PuffOfSmoke");
 
         Invoke("DestroyObject", 0.67f); //Delay to play animation
+    }
+
+    void DisableVelocity()
+    {
+        hitDone = true;
+        rb.velocity = Vector2.zero;
     }
 
     void DestroyObject()

--- a/_Enemy Scripts/OrbController.cs
+++ b/_Enemy Scripts/OrbController.cs
@@ -39,7 +39,7 @@ public class OrbController : MonoBehaviour
         xV = Random.Range(xVelocityLower, xVelocityUpper);
         yV = Random.Range(yVelocityLower, yVelocityUpper);
 
-        player = GameManager.Instance.PlayerTargetOffset;
+        player = GameManager.Instance.playerTargetOffset;
         inventory = GameManager.Instance.Inventory;
         animator = GetComponent<Animator>();
         hitDone = false;

--- a/_Enemy Scripts/OrbController.cs
+++ b/_Enemy Scripts/OrbController.cs
@@ -1,36 +1,35 @@
 using System.Collections;
 using System.Collections.Generic;
-using UnityEditor.Rendering;
 using UnityEngine;
 
 public class OrbController : MonoBehaviour
 {
-    private float startChaseDelay = .5f;
+    protected float startChaseDelay = .5f;
     public float orbSpeed = 5f;
 
     [Header("Debugging")]
-    [SerializeField] private bool findPlayer;
+    [SerializeField] protected bool findPlayer;
 
     [Space(10)]
 
-    Rigidbody2D rb;
-    CircleCollider2D collider;
-    Transform player;
-    Inventory inventory;
-    Animator animator;
+    protected Rigidbody2D rb;
+    protected CircleCollider2D collider;
+    protected Transform player;
+    protected Inventory inventory;
+    protected Animator animator;
 
-    Vector2 launchForce;
+    protected Vector2 launchForce;
     public float direction = -1f; //-1 = left, 1 = right
-    float xV, yV;
-    [SerializeField] float xVelocityLower = 100;
-    [SerializeField] float xVelocityUpper = 130;
-    [SerializeField] float yVelocityLower = 130;
-    [SerializeField] float yVelocityUpper = 160;
+    protected float xV, yV;
+    [SerializeField] protected float xVelocityLower = 100;
+    [SerializeField] protected float xVelocityUpper = 130;
+    [SerializeField] protected float yVelocityLower = 130;
+    [SerializeField] protected float yVelocityUpper = 160;
 
+    protected bool hitDone;
+    protected bool xpGiven;
 
-    private bool hitDone;
-
-    private void Awake()
+    protected virtual void Awake()
     {
         rb = GetComponent<Rigidbody2D>();
         collider = GetComponent<CircleCollider2D>();
@@ -43,17 +42,18 @@ public class OrbController : MonoBehaviour
         inventory = GameManager.Instance.Inventory;
         animator = GetComponent<Animator>();
         hitDone = false;
+        xpGiven = false;
     }
 
-    private void OnEnable()
+    protected virtual void OnEnable()
     {
-        direction = Random.Range(-1f, 1f); //TODO: testing, random left/up/right
-        launchForce = new Vector2((direction * xV), yV);
+        direction = Random.Range(-1f, 1f); //random left/up/right
+        launchForce = new Vector2(direction * xV, yV);
         rb.AddForce(launchForce);
         StartCoroutine(MoveToPlayer());
     }
 
-    private void FixedUpdate()
+    protected virtual void FixedUpdate()
     {
         if (!findPlayer || hitDone) return;
 
@@ -67,14 +67,14 @@ public class OrbController : MonoBehaviour
         }
     }
 
-    IEnumerator MoveToPlayer()
+    protected IEnumerator MoveToPlayer()
     {
         if (player != null) yield return null;
         yield return new WaitForSeconds(startChaseDelay);
         DisableColliderGrav();
     }
 
-    void DisableColliderGrav()
+    protected void DisableColliderGrav()
     {
         findPlayer = true;
         collider.isTrigger = true; //allows orbs to fly through ground/walls
@@ -82,28 +82,35 @@ public class OrbController : MonoBehaviour
         rb.drag = 0;
     }
 
-    void HitPlayer()
+    protected virtual void HitPlayer()
     {
         //Check to make sure hits aren't registered multiple times on collision
         if (hitDone) return;
-        // hitDone = true;
+        // hitDone = true
+        GiveGold(); //GiveXP
 
         Invoke("DisableVelocity", .25f);
 
-        inventory.UpdateGold(1); //GiveXP
         animator.Play("PuffOfSmoke");
-
         Invoke("DestroyObject", 0.67f); //Delay to play animation
     }
 
-    void DisableVelocity()
+    private void GiveGold()
+    {
+        if(xpGiven) return;
+        xpGiven = true;
+        inventory.UpdateGold(1); 
+    }
+
+    protected void DisableVelocity()
     {
         hitDone = true;
         rb.velocity = Vector2.zero;
     }
 
-    void DestroyObject()
+    protected void DestroyObject()
     {
         Destroy(this.gameObject);
     }
+
 }

--- a/_Enemy Scripts/OrbController_Heal.cs
+++ b/_Enemy Scripts/OrbController_Heal.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class OrbController_Heal : OrbController
+{
+
+    [Space(20)]
+    [Header("- Heal Orb override -")]
+    [SerializeField] Base_PlayerCombat playerCombat;
+    [SerializeField] float healAmount = 2;
+
+    // [SerializeField] private bool playerInRange = false;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        // playerInRange = false;
+    }
+
+    protected override void OnEnable()
+    {
+        base.OnEnable();
+        playerCombat = GameManager.Instance.PlayerCombat;
+    }
+
+    //HitPlayer
+    protected override void HitPlayer()
+    {
+        if(hitDone) return;
+        GiveHeal(); //Heal Player
+
+        Invoke("DisableVelocity", .25f);
+
+        animator.Play("PuffOfSmoke");
+        Invoke("DestroyObject", 0.67f); //Delay to play animation
+    }
+
+    private void GiveHeal()
+    {
+        if(xpGiven) return;
+        xpGiven = true;
+        playerCombat.HealPlayer(healAmount);
+    }
+
+    // void OnTriggerEnter2D(Collider2D collision)
+    // {
+    //     var playerCollider = collision.GetComponent<Base_PlayerCombat>();
+    //     if(playerCollider == null) return;
+
+    //     playerInRange = true;
+    //     StartCoroutine(MoveToPlayer());
+    // }
+}

--- a/_Enemy Scripts/OrbController_Heal.cs.meta
+++ b/_Enemy Scripts/OrbController_Heal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4b1248370b58934eb897db009705798
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Enemy Scripts/ProjectileController.cs
+++ b/_Enemy Scripts/ProjectileController.cs
@@ -42,7 +42,7 @@ public class ProjectileController : MonoBehaviour
             {
                 //Player parried, flip direction
                 target.TakeDamage(damage, transform.position.x, true, 2);
-                if(target.isParrying)
+                if(target.parryDeflecting)
                 {
                     enemyProj = false;
                     gameObject.layer = LayerMask.NameToLayer("ProjectilePlayer");
@@ -72,7 +72,6 @@ public class ProjectileController : MonoBehaviour
 
     private void DestroyProjectile()
     {
-        Debug.Log("Destroyed projectile");
         //Stops projectile on hit or when expiring, then plays the hit animation
         projectileHit = true;
         collider.enabled = false;

--- a/_Level Generator/RoomGenerator.cs
+++ b/_Level Generator/RoomGenerator.cs
@@ -92,7 +92,7 @@ public class RoomGenerator : MonoBehaviour
                 CreateRoom(RoomGuarantees[i], availableIndexes[randRoomIndex]);
             }
             else{
-                int randShop = Random.Range(0, totalShops); //Pick random shop from array of variations
+                int randShop = Random.Range(0, Shops.Length); //Pick random shop from array of variations
                 CreateRoom(Shops[randShop], availableIndexes[randRoomIndex]);
             }
         }

--- a/_Level_Scene_Load/EnemyStageManager.cs
+++ b/_Level_Scene_Load/EnemyStageManager.cs
@@ -29,6 +29,12 @@ public class EnemyStageManager : MonoBehaviour
     [SerializeField] private int currWaveEnemyCount;
     private DoorManager doorManager;
 
+    [Space(10)]
+    [Header("- Clear Rewards -")]
+    [SerializeField] GameObject[] clearRewardPrefabs;
+    [SerializeField] int[] clearRewardsQuantity;
+    [SerializeField] Transform rewardSpawnPoint;
+
     void Start()
     {
         roomManager = GetComponentInParent<RoomClear>();
@@ -127,7 +133,9 @@ public class EnemyStageManager : MonoBehaviour
         else numSpawns = enemyCount + 1;
 
         for(int i = 0; i < numSpawns; i++)
+        {
             enemyParentObj.GetChild(i).gameObject.SetActive(true);
+        }
         
         //Boss is already enabled, manually starting spawn
         if(bossRoom)
@@ -176,6 +184,24 @@ public class EnemyStageManager : MonoBehaviour
     {
         if (enemyCount > 0) enemyCount--;
         CheckWaveCount();
-        if (enemyCount <= 0) roomManager.Cleared();
+        if (enemyCount <= 0)
+        {
+            roomManager.Cleared();
+            SpawnClearRewards();
+        }
+    }
+
+    private void SpawnClearRewards()
+    {
+        if(clearRewardPrefabs.Length == 0) return;
+        if(rewardSpawnPoint == null) rewardSpawnPoint = transform;
+
+        for(int i=0; i<clearRewardPrefabs.Length; i++)
+        {
+            for(int j=0; j<clearRewardsQuantity[i]; j++)
+            {
+                Instantiate(clearRewardPrefabs[i], rewardSpawnPoint.position, Quaternion.identity);
+            }
+        }
     }
 }

--- a/_Manager Handler Scripts/GameManager.cs
+++ b/_Manager Handler Scripts/GameManager.cs
@@ -6,18 +6,24 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
 
+    [Space(10)]
     public bool inputAllowed;
     public bool shopOpen;
     public bool rewardOpen;
     public PauseMenu Pause;
-    public Transform Player;
 
+    [Space(10)]
+    [Header("- Player References -")]
+    public Transform playerTransform;
     public Base_PlayerMovement PlayerMovement;
     public Base_PlayerCombat PlayerCombat;
-    public Transform PlayerTargetOffset;
+    public Transform playerTargetOffset;
+    public int PlayerCurrPlatform;
+
+    [Space(20)]
+    [Header("- Augments -")]
     public AugmentInventory AugmentInventory;
     public Inventory Inventory;
-    public int PlayerCurrPlatform;
     public AugmentPool AugmentPool;
 
     private void Awake()
@@ -25,10 +31,10 @@ public class GameManager : MonoBehaviour
         Instance = this;
 
         if (Pause == null) Pause = GameObject.Find("Menu UI Canvas").GetComponent<PauseMenu>();
-        Player = GameObject.FindGameObjectWithTag("Player").transform;
-        PlayerMovement = Player.GetComponent<Base_PlayerMovement>();
-        PlayerCombat = Player.GetComponent<Base_PlayerCombat>();
-        PlayerTargetOffset = GameObject.FindGameObjectWithTag("PlayerTargetOffset").transform;
+        playerTransform = GameObject.FindGameObjectWithTag("Player").transform;
+        PlayerMovement = playerTransform.GetComponent<Base_PlayerMovement>();
+        PlayerCombat = playerTransform.GetComponent<Base_PlayerCombat>();
+        playerTargetOffset = GameObject.FindGameObjectWithTag("PlayerTargetOffset").transform;
         if (Inventory == null) Inventory = GetComponent<Inventory>();
 
         shopOpen = false;
@@ -46,7 +52,7 @@ public class GameManager : MonoBehaviour
 
     public void MovePlayer(Vector3 newPos)
     {
-        Player.position = newPos;
+        playerTransform.position = newPos;
     }
 
     public void TogglePlayerInput(bool toggle)

--- a/_Manager Handler Scripts/HitStop.cs
+++ b/_Manager Handler Scripts/HitStop.cs
@@ -11,6 +11,9 @@ public class HitStop : MonoBehaviour
     {
         if (waiting) return;
         Time.timeScale = timeScale;
+
+        duration *= timeScale; //scale duration to timeScale (replacing Realtime)
+
         StartCoroutine(Wait(duration));
     }
 
@@ -22,8 +25,10 @@ public class HitStop : MonoBehaviour
     IEnumerator Wait(float duration)
     {
         waiting = true;
-        yield return new WaitForSecondsRealtime(duration);
-        // yield return new WaitForSeconds(duration); //use realtime, timeScale is being changed
+
+        // yield return new WaitForSecondsRealtime(duration); //Using Realtime interferes with Pause
+        yield return new WaitForSeconds(duration);
+        
         Time.timeScale = 1.0f;
         waiting = false;
     }

--- a/_Manager Handler Scripts/InstantiateManager.cs
+++ b/_Manager Handler Scripts/InstantiateManager.cs
@@ -16,6 +16,7 @@ public class InstantiateManager : MonoBehaviour
     //public HitEffectsHandler OnKillEffects;
 
     public OrbManager XPOrbs;
+    public OrbManager HealOrbs;
 
     void Awake()
     {
@@ -26,7 +27,6 @@ public class InstantiateManager : MonoBehaviour
         if(TextPopups == null) TextPopups = GameObject.FindGameObjectWithTag("TextPopupsHandler").GetComponent<TextPopupsHandler>();
         if(HitEffects == null) HitEffects = GetComponentInChildren<HitEffectsHandler>();
         //if(OnKillEffects == null) OnKillEffects = GameObject.Find("OnKillEffects").GetComponent<HitEffectsHandler>();
-        if(XPOrbs == null) XPOrbs = GetComponentInChildren<OrbManager>();
+        // if(XPOrbs == null) XPOrbs = GetComponentInChildren<OrbManager>();
     }
-    
 }

--- a/_Manager Handler Scripts/Room Managers/PlayerDoorController.cs
+++ b/_Manager Handler Scripts/Room Managers/PlayerDoorController.cs
@@ -22,7 +22,7 @@ public class PlayerDoorController : MonoBehaviour
         if(!doorController.isOpen) return;
         if(collision.CompareTag("Player"))
         {
-            GameManager.Instance.Player.position = teleportEndpoint.position;
+            GameManager.Instance.playerTransform.position = teleportEndpoint.position;
         }
     }
 }

--- a/_Manager Handler Scripts/Room Managers/RoomClear.cs
+++ b/_Manager Handler Scripts/Room Managers/RoomClear.cs
@@ -41,8 +41,7 @@ public class RoomClear : MonoBehaviour
         {
             DoorManager.RevealDoors(true);
             if(stageManager != null) stageManager.ToggleMinimapIcon(true);
-        } 
-        
+        }
 
         // DoorManager.DelayedRevealDoor();
     }
@@ -59,6 +58,7 @@ public class RoomClear : MonoBehaviour
     {
         //TimeManager.Instance.DoFreezeTime(.15f, .05f);
         Debug.Log("Room Cleared");
+        GameManager.Instance.AugmentInventory.OnRoomClear();
         StartCoroutine(DelayClear());
         //if this breaks, update enemyCount with enemyCount = EnemyList.transform.childCount
     }
@@ -85,6 +85,8 @@ public class RoomClear : MonoBehaviour
         //TimeManager.Instance.DoSlowMotion();
         roomCleared = true;
     }
+
+    
 
     public void CheckSpawn()
     {

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -53,6 +53,7 @@ public class Base_PlayerCombat : MonoBehaviour
     public float blockDelay;
     public float blockDuration;
     private float blockDelayAndDuration;
+    public bool parryDeflecting;
 
     [Space(10)]
 
@@ -127,6 +128,7 @@ public class Base_PlayerCombat : MonoBehaviour
         isAttacking = false;
         isAirAttacking = false;
         isParrying = false;
+        parryDeflecting = false;
         currentAttack = 0;
         currentAirAttack = 0;
         currAttackIndex = 0;
@@ -297,6 +299,9 @@ public class Base_PlayerCombat : MonoBehaviour
 
     void ParryCounter()
     {
+        parryDeflecting = true;
+        Invoke("ResetParrying", blockDuration);
+
         Collider2D[] hitEnemies = 
             Physics2D.OverlapBoxAll(parryPoint.position,
             new Vector2(parryHitBoxLength, parryHitboxHeight), 0, enemyLayer);
@@ -315,6 +320,11 @@ public class Base_PlayerCombat : MonoBehaviour
                 hitStop.Stop(); //Successful hit //.083f is 1 frame
             }
         }
+    }
+
+    void ResetParrying()
+    {
+        parryDeflecting = false;
     }
 
     public void Block()


### PR DESCRIPTION
### Augments
- Updated descriptions to insert the upgraded stat into the base description
  - Base descriptions updated with '#' character as a placeholder to be replaced on update
- OnClear conditional augment setup
- Added Upgrade Augment Shop
  - Only pulls from the Player's owned augments
  - Player can only access if they have at least 3 augments

### Enemies
- Added player transform references to enemies to replace playerToRight raycast updater
- **Trial Rooms**
  - Added Heal Orb, same behavior as XP Orbs
  - Trials rooms now spawn Heal Orbs on clear
  - Colossal Boss now drops Heal Orbs on death
 
### Misc
- HitStop switched back to WaitForSeconds, Realtime was interfering with Pause
  - Slow time duration is now scaled to the current timeScale
- Reduced number of Shops to 4 (Normal, Healing, Blood, Upgrade)
- Added background props to all Rooms and Shops
- XP Orbs now play hit animation then stop following the Player
- Added variable delay on explosion hit checks

### Bug Fixes
- Fixed Parry being able to deflect projectiles behind the Player
- Fixed enemy animation timings for attack coroutines
- Fixed bug with Level generator using the incorrect Shops count variable
- Fixed Boss floating if changing health phases while flying
- Fixed Shops not being able to be closed after getting a Reward augment