### PR TITLE
Dagger enemy added, Enemy behavior fixes

### DIFF
--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -77,6 +77,7 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
     public bool isAttacking;
     // public bool playerToRight; //Updated somewhere //TODO:
     public bool altAttacking;
+    [SerializeField] protected bool damageImmune;
     public float kbResist = 0;
     public bool knockbackImmune = false;
     Coroutine StunnedCO;
@@ -113,6 +114,7 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         isKnockedback = false;
         isLunging = false;
         knockbackImmune = false;
+        damageImmune = false;
         if (healthBar == null) healthBar = GetComponentInChildren<HealthBar>();
         if (healthBar != null)
         {
@@ -142,7 +144,9 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         altAttacking = false;
         //Must be in Start(), because of player scene loading.
         //Awake() might work during actual build with player scene always being active before enemy scenes.
-        enemyStageManager = transform.parent.parent.GetComponent<EnemyStageManager>();
+        if(transform.parent.parent == null) Debug.Log("No Enemy StageManager");
+        else enemyStageManager = transform.parent.parent.GetComponent<EnemyStageManager>();
+        
         playerTransform = GameManager.Instance.playerTransform;
     }
 
@@ -426,6 +430,7 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
     public virtual void TakeDamage(float damageTaken, bool knockback = false, float strength = 8, float xPos = 0)
     {
         if (!isAlive || isSpawning) return;
+        if (damageImmune) return;
 
         HitFlash(); //Set material to white, short delay before resetting
 
@@ -486,6 +491,11 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
     public virtual void ToggleHealthbar(bool toggle)
     {
         healthBar.gameObject.SetActive(toggle);
+    }
+
+    public virtual void ToggleDamageImmune(bool toggle)
+    {
+        damageImmune = toggle;
     }
 
     protected virtual void Die()

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -385,12 +385,18 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
     {
         // KnockbackNullCheckCO();
         LungeNullCheckCO();
+        // if(strength <= 0) return;
         Debug.Log("lunge called");
         // isKnockedback = true;
         isLunging = true;
         movement.ToggleFlip(false);
 
-        float lungeDir = lungeToRight != true ? 1 : -1; //lunge towards player
+        // float lungeDir = lungeToRight != true ? 1 : -1; //lunge towards player
+
+        float lungeDir;
+        if(lungeToRight) lungeDir = 1;
+        else lungeDir = -1;
+
         // Vector2 direction = new Vector2(lungeDir, movement.rb.velocity.y);
         // movement.rb.AddForce(direction * strength, ForceMode2D.Impulse);]
         movement.rb.velocity = new Vector2(lungeDir * strength, movement.rb.velocity.y);
@@ -402,14 +408,17 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
     IEnumerator LungeReset(float delay, float recoveryDelay = .1f)
     {
         yield return new WaitForSeconds(delay);
+        movement.rb.velocity = Vector3.zero;
         movement.canMove = false;
-        movement.rb.velocity = Vector2.zero;
+        movement.ToggleFlip(false);
         yield return new WaitForSeconds(recoveryDelay); //delay before allowing move again
-        movement.canMove = true; //TODO: avoid overlapping canMove resets
-
-        movement.ToggleFlip(true);
-        
         isLunging = false;
+
+        if(!isAttacking)
+        {
+            movement.ToggleFlip(true);
+            movement.canMove = true; //TODO: avoid overlapping canMove resets
+        }
     }
 
     void LungeNullCheckCO()

--- a/_Enemy Scripts/Base_EnemyController.cs
+++ b/_Enemy Scripts/Base_EnemyController.cs
@@ -92,12 +92,13 @@ public class Base_EnemyController : MonoBehaviour
     protected virtual void AttackCheckClose()
     {
         //Only attack the player if they're on the same platform
-        if (!PlatformCheck()) return;
+        if (!PlatformCheck() || combat.altAttacking) return;
         if (raycast.playerInRangeClose) combat.AttackClose();
     }
 
     protected virtual void AttackCheckFar()
     {
+        if (combat.altAttacking) return;
         //Ranged enemies can attack the player on separate platforms if in range
         if (!PlatformCheck() && !isRangedAttack) return;
         if (raycast.playerInRangeFar && combat.CanAttackFar()) combat.AttackFar();
@@ -129,16 +130,16 @@ public class Base_EnemyController : MonoBehaviour
                 StopIdling();
                 movement.canMove = true;
             }
-            movement.MoveRight(raycast.playerDetectedToRight);
+            // movement.MoveRight(raycast.playerDetectedToRight);
+            movement.MoveRight(raycast.playerToRight);
         }
         // else playerDetected = false; //-
     }
 
     protected void MoveCheck()
     {
-        // if (playerDetected) return;
         // if(combat.isAttacking || combat.altAttacking) return;
-        if(combat.isAttacking) return;
+        if(combat.isAttacking || playerDetected) return;
 
         //LedgeCheck raycast or wallcheck to turn around
         if (raycast.ledgeDetect) //&& movement.canMove)
@@ -158,7 +159,10 @@ public class Base_EnemyController : MonoBehaviour
                 float coDuration = Random.Range(CODurationLower, CODurationUpper);
 
                 if (idleSwitch) StartPatrol(coDuration, switchDir);
-                else StartIdle(coDuration, switchDir);
+                else 
+                {
+                    StartIdle(coDuration, switchDir);
+                }
             }
         }
     }
@@ -181,7 +185,7 @@ public class Base_EnemyController : MonoBehaviour
     {
         isIdling = true;
         movement.canMove = false;
-        movement.DisableMove();
+        // movement.DisableMove();
         if (switchDir)
             FlipDir();
 
@@ -198,6 +202,7 @@ public class Base_EnemyController : MonoBehaviour
 
     protected void StopPatrolling()
     {
+        if(!isPatrolling) return;
         if (PatrolCO != null)
             StopCoroutine(PatrolCO);
 

--- a/_Enemy Scripts/Base_EnemyController.cs
+++ b/_Enemy Scripts/Base_EnemyController.cs
@@ -28,6 +28,7 @@ public class Base_EnemyController : MonoBehaviour
     {
         if(movement == null) movement = GetComponent<Base_EnemyMovement>();
         if(combat == null) combat = GetComponent<Base_EnemyCombat>();
+        if(raycast == null) raycast = GetComponentInChildren<Base_EnemyRaycast>();
     }
 
     protected virtual void Start()
@@ -64,6 +65,7 @@ public class Base_EnemyController : MonoBehaviour
         StartLanding();
 
         MoveCheck();
+
         LedgeWallCheck();
         ChasePlayer();
 
@@ -111,6 +113,7 @@ public class Base_EnemyController : MonoBehaviour
 
     protected void ChasePlayer()
     {
+        if (!combat.chasePlayer) return;
         if (!movement.canMove) return;
         if (raycast.currPlatform != currPlayerPlatform) return;
         if (raycast.wallDetect || !raycast.ledgeDetect) return; //May not be needed with platform check
@@ -133,7 +136,9 @@ public class Base_EnemyController : MonoBehaviour
 
     protected void MoveCheck()
     {
-        if (playerDetected) return;
+        // if (playerDetected) return;
+        // if(combat.isAttacking || combat.altAttacking) return;
+        if(combat.isAttacking) return;
 
         //LedgeCheck raycast or wallcheck to turn around
         if (raycast.ledgeDetect) //&& movement.canMove)
@@ -148,9 +153,9 @@ public class Base_EnemyController : MonoBehaviour
             //Switch between Patrolling or Idling, and the duration to run the action
             if (!isPatrolling && !isIdling)
             {
-                bool switchDir = (Random.value > .5f);
-                bool idleSwitch = (Random.value > .5f);
-                float coDuration = (Random.Range(CODurationLower, CODurationUpper));
+                bool switchDir = Random.value > .5f;
+                bool idleSwitch = Random.value > .5f;
+                float coDuration = Random.Range(CODurationLower, CODurationUpper);
 
                 if (idleSwitch) StartPatrol(coDuration, switchDir);
                 else StartIdle(coDuration, switchDir);

--- a/_Enemy Scripts/Base_EnemyController.cs
+++ b/_Enemy Scripts/Base_EnemyController.cs
@@ -66,6 +66,7 @@ public class Base_EnemyController : MonoBehaviour
         MoveCheck();
         LedgeWallCheck();
         ChasePlayer();
+
         AttackCheckClose();
         AttackCheckFar();
         // PlayerToRightCheck();
@@ -73,6 +74,7 @@ public class Base_EnemyController : MonoBehaviour
 
     protected virtual void FixedUpdate()
     {
+        playerDetected = raycast.aggroed;
         PlatformCheck();
     }
 
@@ -109,12 +111,14 @@ public class Base_EnemyController : MonoBehaviour
 
     protected void ChasePlayer()
     {
+        if (!movement.canMove) return;
         if (raycast.currPlatform != currPlayerPlatform) return;
         if (raycast.wallDetect || !raycast.ledgeDetect) return; //May not be needed with platform check
-
-        if (raycast.playerDetectFront || raycast.playerDetectBack)
+        
+        // if (raycast.playerDetectFront || raycast.playerDetectBack) //-
+        if (playerDetected)
         {
-            playerDetected = true;
+            // playerDetected = true; //-
             StopPatrolling();
 
             if (isIdling)
@@ -124,7 +128,7 @@ public class Base_EnemyController : MonoBehaviour
             }
             movement.MoveRight(raycast.playerDetectedToRight);
         }
-        else playerDetected = false;
+        // else playerDetected = false; //-
     }
 
     protected void MoveCheck()

--- a/_Enemy Scripts/Base_EnemyMovement.cs
+++ b/_Enemy Scripts/Base_EnemyMovement.cs
@@ -69,6 +69,13 @@ public class Base_EnemyMovement : MonoBehaviour
         Flip();
     }
 
+    public virtual void Jump()
+    {
+        float jumpStrength = 4f;
+        Vector2 jumpDir = new Vector2(rb.velocity.x, jumpStrength);
+        rb.AddForce(jumpDir, ForceMode2D.Impulse);
+    }
+
     public virtual void Lunge(bool lungeToRight, float strength = 4, float duration = .3f)
     {
         canMove = false;

--- a/_Enemy Scripts/Base_EnemyMovement.cs
+++ b/_Enemy Scripts/Base_EnemyMovement.cs
@@ -51,7 +51,8 @@ public class Base_EnemyMovement : MonoBehaviour
     {
         if (!combat.isAlive || combat.isStunned || !canMove)
         {
-            if(!combat.isKnockedback)// || combat.isLunging)// || _isKnockedback)
+            // if(!combat.isKnockedback)// || combat.isLunging)// || _isKnockedback)
+            if(!combat.isKnockedback)
                 DisableMove();
 
             return;
@@ -76,48 +77,11 @@ public class Base_EnemyMovement : MonoBehaviour
         rb.AddForce(jumpDir, ForceMode2D.Impulse);
     }
 
-    public virtual void Lunge(bool lungeToRight, float strength = 4, float duration = .3f)
-    {
-        canMove = false;
-        //Reversed Knockback, moving towards player instead of backwards
-        combat.GetKnockback(!lungeToRight, strength, duration);
-    }
-
-    // public virtual void GetKnockback(bool playerToRight, float strength = 8, float delay = .5f)
+    // public virtual void Lunge(bool lungeToRight, float strength = 4, float duration = .3f)
     // {
-    //     Debug.Log("Knockback called from Movement");
-    //     // KnockbackNullCheckCO();
-
-    //     // if (strength <= 0) return;
-
-    //     // _isKnockedback = true;
-    //     // ToggleFlip(false);
-
-    //     // float temp = playerToRight != true ? 1 : -1; //get knocked back in opposite direction of player
-    //     // Vector2 direction = new Vector2(temp, rb.velocity.y);
-    //     // rb.AddForce(direction * strength, ForceMode2D.Impulse);
-
-    //     // LungingCO = StartCoroutine(KnockbackReset(delay));
-    // }
-
-    // IEnumerator KnockbackReset(float delay, float recoveryDelay = .1f)
-    // {
-    //     yield return new WaitForSeconds(delay);
-    //     rb.velocity = Vector3.zero;
     //     canMove = false;
-    //     yield return new WaitForSeconds(recoveryDelay); //delay before allowing move again
-    //     canMove = true;
-    //     ToggleFlip(true);
-    //     _isKnockedback = false;
-    // }
-
-    // void KnockbackNullCheckCO()
-    // {
-    //     if (LungingCO == null) return;
-    //     StopCoroutine(LungingCO);
-    //     canMove = true;
-    //     ToggleFlip(true);
-    //     _isKnockedback = false;
+    //     //Reversed Knockback, moving towards player instead of backwards
+    //     combat.GetKnockback(!lungeToRight, strength, duration);
     // }
 
     #region Flip
@@ -153,7 +117,7 @@ public class Base_EnemyMovement : MonoBehaviour
     #endregion
 
     #region Toggles
-    public void DisableMove()
+    public void DisableMove() //controlled when canMove is false
     {
         rb.velocity = new Vector2(0, rb.velocity.y);
     }

--- a/_Enemy Scripts/Base_EnemyRaycast.cs
+++ b/_Enemy Scripts/Base_EnemyRaycast.cs
@@ -18,7 +18,7 @@ public class Base_EnemyRaycast : MonoBehaviour
         backToWallCheck,
         backToLedgeCheck;
 
-    [Space]
+    [Space(10)]
     [Header("=== Adjustable Variables ===")] //Raycast variables
     [SerializeField] private float ledgeCheckDistance = 0.05f;
     [SerializeField]
@@ -29,16 +29,18 @@ public class Base_EnemyRaycast : MonoBehaviour
     public float attackRangeClose = 0.67f; //when to start attacking player, uses a raycast to detect if player is within range
     public float attackRangeFar = 1f;
 
-    [Space]
+    [Space(10)]
     [Header("Current Platform")]
     public int currPlatform;
     [SerializeField] private bool updatePlatform;
 
-    [Space]
+    [Space(10)]
     [Header("=== Raycast Checks ===")]
     [SerializeField] Transform playerTransform;
+    public float distanceToPlayer;
     public bool playerToRight;
     public bool playerDetectedToRight;
+    public bool aggroed;
     [SerializeField]
     public bool
         playerDetectFront,
@@ -78,7 +80,10 @@ public class Base_EnemyRaycast : MonoBehaviour
         // movement.canFlip = isGrounded;
         
         //Not grounded, allow CheckPlatform() to get platform ID once
-        if (isGrounded) if(updatePlatform) CheckPlatform();
+        if (isGrounded)
+        {
+            if(updatePlatform) CheckPlatform();
+        }
         else updatePlatform = true;
 
         AttackCheck();
@@ -86,6 +91,7 @@ public class Base_EnemyRaycast : MonoBehaviour
         PlayerDetectCheck();
         UpdatePlayerToRight();
         UpdatePlayerDetectedToRight();
+        GetDistToPlayer();
     }
 
     // void FixedUpdate()
@@ -113,8 +119,11 @@ public class Base_EnemyRaycast : MonoBehaviour
         Vector3 down = transform.TransformDirection(Vector3.down) * ledgeCheckDistance;
         Debug.DrawRay(ledgeCheck.position, down, Color.green);
 
-        Vector3 right = transform.TransformDirection(Vector3.right) * wallCheckDistance;
-        //Debug.DrawRay(wallPlayerCheck.position, right, Color.blue);
+        if(wallPlayerCheck != null)
+        {
+            Vector3 right = transform.TransformDirection(Vector3.right) * wallCheckDistance;
+            Debug.DrawRay(wallPlayerCheck.position, right, Color.blue);
+        }
 
         Vector3 attackRight = transform.TransformDirection(Vector3.right) * playerCheckDistanceFront;
         Debug.DrawRay(wallPlayerCheck.position, attackRight, Color.cyan);
@@ -128,6 +137,11 @@ public class Base_EnemyRaycast : MonoBehaviour
         Vector3 playerInAttackRangeClose = transform.TransformDirection(Vector3.right) * attackRangeClose;
         Debug.DrawRay(attackCheck.position, playerInAttackRangeClose, Color.magenta);
 
+        if(backToLedgeCheck != null)
+        {
+            Vector3 ledgeCheckBack = transform.TransformDirection(Vector3.down) * ledgeCheckDistance;
+            Debug.DrawRay(backToLedgeCheck.position, ledgeCheckBack, Color.green);
+        }
     }
 
     void AttackCheck()
@@ -144,7 +158,7 @@ public class Base_EnemyRaycast : MonoBehaviour
         //Optional checks (not used for all Enemies)
         if(backToWallCheck != null)
         {
-            backToWall = Physics2D.Raycast(wallPlayerCheck.position, transform.right, -wallCheckDistance, groundLayer);
+            backToWall = Physics2D.Raycast(wallPlayerCheck.position, -transform.right, wallCheckDistance, groundLayer);
         }
 
         if(backToLedgeCheck != null)
@@ -164,11 +178,25 @@ public class Base_EnemyRaycast : MonoBehaviour
         playerToRight = transform.position.x < playerTransform.position.x;
     }
 
+    public void GetDistToPlayer()
+    {
+        distanceToPlayer = Mathf.Abs(transform.position.x - playerTransform.position.x);
+    }
+
     void UpdatePlayerDetectedToRight()
     {
         // Updates 'playerDetectedToRight' bool using raycasts
-        if (playerDetectFront)  playerDetectedToRight = movement.isFacingRight;
-        else if (playerDetectBack)  playerDetectedToRight = !movement.isFacingRight;
+        if (playerDetectFront)
+        {
+            playerDetectedToRight = movement.isFacingRight;
+            aggroed = true;
+        }
+        else if (playerDetectBack)
+        {
+            playerDetectedToRight = !movement.isFacingRight;
+            aggroed = true;
+        }
+        else aggroed = false;
         //! don't use this for knockback, won't behave correctly if the player is midair or the enemy can't update
 
         //if (playerDetectFront)

--- a/_Enemy Scripts/Base_EnemyRaycast.cs
+++ b/_Enemy Scripts/Base_EnemyRaycast.cs
@@ -32,7 +32,8 @@ public class Base_EnemyRaycast : MonoBehaviour
     [Space(10)]
     [Header("Current Platform")]
     public int currPlatform;
-    [SerializeField] private bool updatePlatform;
+    [SerializeField] protected bool updatePlatform;
+    [SerializeField] protected float updatingPlatformTimer;
 
     [Space(10)]
     [Header("=== Raycast Checks ===")]
@@ -82,9 +83,13 @@ public class Base_EnemyRaycast : MonoBehaviour
         //Not grounded, allow CheckPlatform() to get platform ID once
         if (isGrounded)
         {
-            if(updatePlatform) CheckPlatform();
+            CheckPlatform();
         }
-        else updatePlatform = true;
+        else
+        {
+            updatingPlatformTimer = 2;
+            updatePlatform = true;
+        }
 
         AttackCheck();
         LedgeWallCheck();
@@ -107,11 +112,17 @@ public class Base_EnemyRaycast : MonoBehaviour
     void CheckPlatform()
     {
         //Only updating platform after IsGrounded() returns false, then update once
-        // if (!updatePlatform) return;
+        if (!updatePlatform) return;
+
+        if(updatingPlatformTimer > 0)
+        {
+            updatingPlatformTimer -= Time.deltaTime;
+        }
+        else updatePlatform = false;
 
         int i = Physics2D.OverlapCircle(groundCheck.position, 0.01f, groundLayer).GetInstanceID();
         if (i != currPlatform) currPlatform = i;
-        updatePlatform = false;
+        // updatePlatform = false;
     }
 
     void DebugDrawRaycast()

--- a/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs
@@ -1,0 +1,157 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Dagger_Lunge : Base_CombatBehavior
+{
+    
+    [Header("= LungeAttack =")]
+    [SerializeField] Rigidbody2D rb;
+    [SerializeField] Animator anim;
+    [SerializeField] bool canLunge;
+    [SerializeField] int currAttack;
+    [SerializeField] float[] fullAnimTimes;
+    [SerializeField] float[] animDelayTimes;
+
+    [Space(10)]
+    [Header("= Lunge HitBox =")]
+    [SerializeField] bool showGizmos = false;
+    [SerializeField] Transform[] attackPoint;
+    [SerializeField] float[] hitboxWidth;
+    [SerializeField] float[] hitboxHeight;
+
+    protected override void Start()
+    {
+        base.Start(); //base script references
+        canLunge = true;
+        if(anim == null) anim = GetComponentInChildren<Animator>();
+        if(rb == null) rb = GetComponent<Rigidbody2D>();
+
+        currAttack = 0;
+    }
+
+    public override void Attack()
+    {
+        if(!canLunge || !combat.isAlive) return;
+
+        if(combat.isAttacking) return;
+        if(currAttack == 0)
+        {
+            StartCoroutine(LungeAttackCO());
+        }else{
+            StartCoroutine(SwipeAttackCO());
+        }
+    }
+
+    void Update()
+    {
+        if(Input.GetKeyDown(KeyCode.N))
+        {
+            // TESTLUNGE();
+            combat.Lunge(movement.isFacingRight, 8);
+        }
+    }
+
+    IEnumerator LungeAttackCO()
+    {
+        Debug.Log("starting lunge Dagger");
+        canLunge = false;
+        combat.isAttacking = true;
+        combat.altAttacking = true;
+
+        // combat.knockbackImmune = true;
+
+        yield return new WaitForSeconds(chargeUpAnimDelay);
+
+        //Attack 1
+        combat.animator.PlayManualAnim(0, fullAnimTimes[0]);
+        // StartLunge(raycast.playerToRight);
+        combat.Lunge(movement.isFacingRight);
+        yield return new WaitForSeconds(AnimDelayTime(0));
+        CheckHit(0);
+
+        yield return new WaitForSeconds(GetFullAnimTime(0) - AnimDelayTime(0));
+
+        //Attack 2
+        combat.animator.PlayManualAnim(1, fullAnimTimes[1]);
+        // StartLunge(raycast.playerToRight); //- might not use lunge, since no delay
+        combat.Lunge(movement.isFacingRight);
+        yield return new WaitForSeconds(AnimDelayTime(1));
+        CheckHit(1);
+
+        yield return new WaitForSeconds(GetFullAnimTime(1) - AnimDelayTime(1));
+
+        yield return new WaitForSeconds(attackSpeed);
+
+        canLunge = true;
+        combat.isAttacking = false;
+        combat.altAttacking = false;
+        currAttack = 1;
+        // combat.knockbackImmune = false;
+    }
+
+    IEnumerator SwipeAttackCO()
+    {
+        combat.isAttacking = true;
+
+        combat.animator.PlayManualAnim(2, fullAnimTimes[2]);
+        yield return new WaitForSeconds(AnimDelayTime(2));
+        CheckHit(2);
+        yield return new WaitForSeconds(GetFullAnimTime(2) - AnimDelayTime(2));
+
+        yield return new WaitForSeconds(attackSpeed);
+
+        combat.isAttacking = false;
+        currAttack = 0;
+    }
+
+    // void PlayAnimation(int index)
+    // {
+    //     combat.animator.PlayManualAnim(index, fullAnimTimes[index]);
+    // }
+
+    float GetFullAnimTime(int index)
+    {
+        return fullAnimTimes[index];
+    }
+
+    float AnimDelayTime(int index)
+    {
+        return animDelayTimes[index];
+    }
+
+    private void CheckHit(int index)
+    {
+        // Collider2D[] hitPlayers = Physics2D.OverlapCircleAll(attackPoint.position, combat.attackRange, combat.playerLayer);
+
+        Collider2D[] hitPlayers = Physics2D.OverlapBoxAll(attackPoint[index].position, new Vector2(hitboxWidth[index], hitboxHeight[index]), combat.playerLayer);
+
+        foreach (Collider2D player in hitPlayers)
+        {
+            if (player.GetComponent<Base_PlayerCombat>() != null)
+            {
+                playerHit = true;
+                player.GetComponent<Base_PlayerCombat>().TakeDamage(combat.attackDamage, transform.position.x);
+                //TODO: pass xPos to hit the Player and get < or > to get knockback direction
+                // player.GetComponent<Base_PlayerCombat>().GetKnockback(!combat.playerToRight, combat.knockbackStrength);
+                player.GetComponent<Base_PlayerCombat>().GetKnockback(transform.position.x, combat.knockbackStrength);
+            }
+        }
+    }
+
+    void OnDrawGizmos()
+    {
+        if(showGizmos)
+        {
+            if(attackPoint == null) return;
+
+            Gizmos.color = Color.red;
+
+            for(int i=0; i<hitboxHeight.Length; i++)
+            {
+                Gizmos.DrawWireCube(attackPoint[i].position, new Vector3(hitboxWidth[i], hitboxHeight[i], 0));
+            }
+
+        }
+    }
+}

--- a/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs.meta
+++ b/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 616b809c69955994ab12cec7f148e2c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Enemy Scripts/Enemy Behaviors/Melee_Lunge.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Melee_Lunge.cs
@@ -43,6 +43,7 @@ public class Melee_Lunge : Base_CombatBehavior
         movement.ToggleFlip(false);
         movement.canMove = false;
         combat.isAttacking = true;
+        combat.chasePlayer = true;
 
         //Start Lunge animation
         combat.animator.PlayManualAnim(0, fullAnimTime);
@@ -53,7 +54,9 @@ public class Melee_Lunge : Base_CombatBehavior
         if(allowFlipBeforeAttack) combat.FacePlayer();
 
         combat.knockbackImmune = true;
+
         allowCollision = true;
+        Debug.Log("calling lunge");
         combat.Lunge(movement.isFacingRight, 8f, .2f);
 
         yield return new WaitForSeconds(animEndingTime);
@@ -63,6 +66,7 @@ public class Melee_Lunge : Base_CombatBehavior
 
         movement.canMove = true;
         movement.ToggleFlip(true);
+        combat.chasePlayer = true;
         
         yield return new WaitForSeconds(attackSpeed);
         canLunge = true;

--- a/_Enemy Scripts/Enemy Behaviors/Melee_Lunge.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Melee_Lunge.cs
@@ -10,7 +10,6 @@ public class Melee_Lunge : Base_CombatBehavior
     [SerializeField] bool allowFlipBeforeAttack = false;
     [SerializeField] bool canLunge;
     [SerializeField] public bool isLunging;
-    Coroutine LungingCO;
 
     [SerializeField] bool allowCollision;
 
@@ -32,18 +31,16 @@ public class Melee_Lunge : Base_CombatBehavior
     public override void Attack() 
     {
         if (!canLunge || !combat.isAlive) return;
+
         StartCoroutine(LungeCO());
     }
 
     IEnumerator LungeCO()
     {
-        // knockbackImmune = true;
         playerHit = false;
         canLunge = false;
         movement.ToggleFlip(false);
-        movement.canMove = false;
         combat.isAttacking = true;
-        combat.chasePlayer = true;
 
         //Start Lunge animation
         combat.animator.PlayManualAnim(0, fullAnimTime);
@@ -53,20 +50,16 @@ public class Melee_Lunge : Base_CombatBehavior
 
         if(allowFlipBeforeAttack) combat.FacePlayer();
 
-        combat.knockbackImmune = true;
-
         allowCollision = true;
-        Debug.Log("calling lunge");
-        combat.Lunge(movement.isFacingRight, 8f, .2f);
-
+        // combat.Lunge(movement.isFacingRight, 8f, .2f);
+        combat.GetKnockback(movement.isFacingRight, 8f, .2f);
+        
         yield return new WaitForSeconds(animEndingTime);
         allowCollision = false;
         combat.isAttacking = false;
-        combat.knockbackImmune = false;
 
-        movement.canMove = true;
         movement.ToggleFlip(true);
-        combat.chasePlayer = true;
+        movement.canMove = true;
         
         yield return new WaitForSeconds(attackSpeed);
         canLunge = true;
@@ -81,8 +74,7 @@ public class Melee_Lunge : Base_CombatBehavior
             {
                 playerHit = true;
                 player.GetComponent<Base_PlayerCombat>().TakeDamage(combat.attackDamage, transform.position.x);
-                //TODO: pass xPos to hit the Player and get < or > to get knockback direction
-                // player.GetComponent<Base_PlayerCombat>().GetKnockback(!combat.playerToRight, combat.knockbackStrength);
+                
                 player.GetComponent<Base_PlayerCombat>().GetKnockback(transform.position.x, combat.knockbackStrength);
             }
         }

--- a/_Enemy Scripts/Enemy Behaviors/Melee_Rush.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Melee_Rush.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Melee_Rush : Base_CombatBehavior
+{
+    //Rush towards the player 
+    [Header("= Melee Rush =")]
+    [SerializeField] float rushDuration = 2;
+    [SerializeField] float base_moveSpeed;
+    [SerializeField] float rushMoveSpeed = 2;
+
+    protected override void Start()
+    {
+        base.Start();
+        base_moveSpeed = movement.moveSpeed;
+    }
+
+    public override void Attack()
+    {
+        if(combat.isAttacking) return;
+
+        StartCoroutine(RushCO());
+    }
+
+    IEnumerator RushCO()
+    {
+        Debug.Log("1 - Speeding up moveSpeed");
+        combat.isAttacking = true;
+        // movement.moveSpeed = rushMoveSpeed;
+
+        yield return new WaitForSeconds(rushDuration);
+        combat.GetKnockback(raycast.playerDetectedToRight, 8);
+
+        Debug.Log("2 - Slowing down to base");
+        combat.isAttacking = false;
+        // movement.moveSpeed = base_moveSpeed;
+    }
+}

--- a/_Enemy Scripts/Enemy Behaviors/Melee_Rush.cs.meta
+++ b/_Enemy Scripts/Enemy Behaviors/Melee_Rush.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8fece99452878441a3fd99cc0a2408b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Enemy Scripts/Enemy Behaviors/Ranged_Static.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Ranged_Static.cs
@@ -50,9 +50,10 @@ public class Ranged_Static : Base_CombatBehavior
         combat.isAttacking = false;
 
         movement.canMove = true;
-        yield return new WaitForSeconds(attackSpeed);
+        combat.chasePlayer = true;
         combat.altAttacking = false;
         movement.ToggleFlip(true);
+        yield return new WaitForSeconds(attackSpeed);
         canFire = true;
         canAttack = true;
     }

--- a/_Enemy Scripts/Enemy Behaviors/Ranged_Static.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Ranged_Static.cs
@@ -21,16 +21,17 @@ public class Ranged_Static : Base_CombatBehavior
     public override void Attack()
     {
         if (!canFire || combat.isAttacking) return;
+        // if (!canFire || combat.altAttacking) return;
         StartCoroutine(ShootCO());
     }
 
     IEnumerator ShootCO()
     {
+        combat.isAttacking = true;
         movement.ToggleFlip(false);
         canFire = false;
         canAttack = false;
         movement.canMove = false;
-        combat.isAttacking = true;
         combat.knockbackImmune = true;
         movement.rb.velocity = Vector3.zero;
 

--- a/_Enemy Scripts/Enemy Behaviors/Ranged_Static.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Ranged_Static.cs
@@ -33,7 +33,7 @@ public class Ranged_Static : Base_CombatBehavior
         canAttack = false;
         movement.canMove = false;
         combat.knockbackImmune = true;
-        movement.rb.velocity = Vector3.zero;
+        // movement.rb.velocity = Vector3.zero;
 
         yield return new WaitForSeconds(chargeUpAnimDelay); //Charge up anim
 

--- a/_Enemy Scripts/Tier 2 Enemies/Archer_EnemyController.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Archer_EnemyController.cs
@@ -21,17 +21,18 @@ public class Archer_EnemyController : Base_EnemyController
         lunging = false;
     }
 
-
     protected override void AttackCheckClose()
     {
         if(combat.altAttacking) return; //Check if attack is already started, this prevents Manualflip being called during attack coroutine
         if (!PlatformCheck() || isRangedAttack) return;
+
         if (raycast.playerInRangeClose)
         {
             PlayerDistCheck();
             combat.altAttacking = true;
             StartCoroutine(LungeAttack());
-        }else
+        }
+        else
         {
             combat.altAttacking = true;
             combat.AttackFar();
@@ -46,26 +47,10 @@ public class Archer_EnemyController : Base_EnemyController
         {
             combat.altAttacking = true;
             StartCoroutine(LungeAttack());
+            // combat.AttackFar();
         }
         // base.AttackCheckFar();
     }
-
-    // -- Reference -- DELETE WHEN DONE
-    // protected virtual void AttackCheckClose11()
-    // {
-    //     //Only attack the player if they're on the same platform
-    //     if (!PlatformCheck()) return;
-    //     if (raycast.playerInRangeClose) combat.AttackClose();
-    // }
-
-    // protected virtual void AttackCheckFar11()
-    // {
-    //     //Ranged enemies can attack the player on separate platforms if in range
-    //     if (!PlatformCheck() && !isRangedAttack) return;
-    //     if (raycast.playerInRangeFar && combat.CanAttackFar()) combat.AttackFar();
-    // }
-
-    // ---------------------------------
 
     protected float PlayerDistCheck()
     {
@@ -75,37 +60,49 @@ public class Archer_EnemyController : Base_EnemyController
 
     IEnumerator LungeAttack()
     {
-        //Lunge then flip towards the Player and start Attack
-        LungeCheck();
+        combat.isAttacking = true;
         combat.animator.PlayManualAnim(1, 0.75f); //Vanish
         combat.ToggleHealthbar(false);
-        yield return new WaitForSeconds(0.75f);
+        combat.ToggleDamageImmune(true);
+        yield return new WaitForSeconds(0.2f);
+
+        //Lunge then flip towards the Player and start Attack
+        if(PlayerDistCheck() <= raycast.attackRangeClose) LungeCheck(9);
+        else LungeCheck(0);
+        movement.canMove = false;
+        yield return new WaitForSeconds(0.55f);
+        combat.ToggleDamageImmune(false);
         combat.ToggleHealthbar(true);
         // yield return new WaitForSeconds(.35f);
+        movement.canMove = false;
+        movement.rb.velocity = Vector3.zero;
         
         ManualFlip(raycast.playerToRight);
-        yield return new WaitForSeconds(0.1f);
+        yield return new WaitForSeconds(0.05f);
         // ManualFlip(raycast.playerDetectedToRight);
+        combat.isAttacking = false;
         combat.AttackFar();
     }
 
     public void LungeCheck(float lungeStrength = 4f, float duration = .3f)
     {
         movement.ToggleFlip(false);
-
+        movement.canMove = false;
+        
         if(raycast.playerInRangeClose) //Player too close
         {
+            // lungeStrength += 4;
             if(raycast.backToWall || !raycast.backToLedge)
             {
                 //Lunge forwards
-                lungeStrength += 4;
                 LungeStart(movement.isFacingRight, lungeStrength, duration);
             }
             else
             {
                 //Lunge backwards
-                lungeStrength += 4;
-                LungeStart(!movement.isFacingRight, lungeStrength, duration);
+                LungeStart(movement.isFacingRight, lungeStrength, duration);
+                // LungeStart(!movement.isFacingRight, lungeStrength, duration);
+                // LungeStart(!raycast.playerToRight, lungeStrength, duration);
             }
         }
     }

--- a/_Enemy Scripts/Tier 2 Enemies/Archer_EnemyController.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Archer_EnemyController.cs
@@ -29,7 +29,7 @@ public class Archer_EnemyController : Base_EnemyController
         if (raycast.playerInRangeClose)
         {
             PlayerDistCheck();
-            combat.altAttacking = true;
+            // combat.altAttacking = true;
             StartCoroutine(LungeAttack());
         }
     }
@@ -42,7 +42,7 @@ public class Archer_EnemyController : Base_EnemyController
 
         if (raycast.playerInRangeFar && combat.CanAttackFar())
         {
-            combat.altAttacking = true;
+            // combat.altAttacking = true;
             StartCoroutine(LungeAttack());
         }
     }
@@ -55,6 +55,7 @@ public class Archer_EnemyController : Base_EnemyController
 
     IEnumerator LungeAttack()
     {
+        combat.altAttacking = true;
         combat.chasePlayer = false;
         combat.isAttacking = true;
         combat.animator.PlayManualAnim(1, 0.75f); //Vanish
@@ -81,7 +82,7 @@ public class Archer_EnemyController : Base_EnemyController
 
     public void LungeCheck(float lungeStrength = 4f, float duration = .3f)
     {
-        movement.ToggleFlip(false);
+        // movement.ToggleFlip(false);
         
         if(raycast.playerInRangeClose) //Player too close
         {

--- a/_Enemy Scripts/Tier 2 Enemies/Archer_EnemyController.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Archer_EnemyController.cs
@@ -32,24 +32,19 @@ public class Archer_EnemyController : Base_EnemyController
             combat.altAttacking = true;
             StartCoroutine(LungeAttack());
         }
-        else
-        {
-            combat.altAttacking = true;
-            combat.AttackFar();
-        }
     }
 
     protected override void AttackCheckFar()
     {
         if(combat.altAttacking) return;
+        //Player isn't on the same platform, and enemy doesn't have range
         if (!PlatformCheck() && !isRangedAttack) return;
+
         if (raycast.playerInRangeFar && combat.CanAttackFar())
         {
             combat.altAttacking = true;
             StartCoroutine(LungeAttack());
-            // combat.AttackFar();
         }
-        // base.AttackCheckFar();
     }
 
     protected float PlayerDistCheck()
@@ -60,26 +55,26 @@ public class Archer_EnemyController : Base_EnemyController
 
     IEnumerator LungeAttack()
     {
+        combat.chasePlayer = false;
         combat.isAttacking = true;
         combat.animator.PlayManualAnim(1, 0.75f); //Vanish
         combat.ToggleHealthbar(false);
         combat.ToggleDamageImmune(true);
         yield return new WaitForSeconds(0.2f);
+        movement.canMove = false;
 
         //Lunge then flip towards the Player and start Attack
         if(PlayerDistCheck() <= raycast.attackRangeClose) LungeCheck(9);
         else LungeCheck(0);
-        movement.canMove = false;
+
         yield return new WaitForSeconds(0.55f);
         combat.ToggleDamageImmune(false);
         combat.ToggleHealthbar(true);
         // yield return new WaitForSeconds(.35f);
-        movement.canMove = false;
-        movement.rb.velocity = Vector3.zero;
         
         ManualFlip(raycast.playerToRight);
         yield return new WaitForSeconds(0.05f);
-        // ManualFlip(raycast.playerDetectedToRight);
+        
         combat.isAttacking = false;
         combat.AttackFar();
     }
@@ -87,30 +82,23 @@ public class Archer_EnemyController : Base_EnemyController
     public void LungeCheck(float lungeStrength = 4f, float duration = .3f)
     {
         movement.ToggleFlip(false);
-        movement.canMove = false;
         
         if(raycast.playerInRangeClose) //Player too close
         {
-            // lungeStrength += 4;
             if(raycast.backToWall || !raycast.backToLedge)
             {
                 //Lunge forwards
-                LungeStart(movement.isFacingRight, lungeStrength, duration);
+                combat.Lunge(!raycast.playerDetectedToRight, lungeStrength, duration);
             }
             else
             {
                 //Lunge backwards
-                LungeStart(movement.isFacingRight, lungeStrength, duration);
-                // LungeStart(!movement.isFacingRight, lungeStrength, duration);
-                // LungeStart(!raycast.playerToRight, lungeStrength, duration);
+                combat.Lunge(raycast.playerDetectedToRight, lungeStrength, duration);
             }
+        }else
+        {
+            combat.Lunge(!raycast.playerDetectedToRight, lungeStrength, duration);
         }
-    }
-
-    void LungeStart(bool lungeToRight, float strength = 4f, float duration = .3f)
-    {
-        // combat.animator.PlayManualAnim(1, 0.75f);
-        movement.Lunge(lungeToRight, strength, duration);
     }
 
     void ManualFlip(bool faceRight)

--- a/_Enemy Scripts/Tier 2 Enemies/Dagger_EnemyController.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Dagger_EnemyController.cs
@@ -4,34 +4,28 @@ using UnityEngine;
 
 public class Dagger_EnemyController : Base_EnemyController
 {
-    [Space(20)]
-    [Header("= Dagger =")]
-    [SerializeField] float lungeDist = .2f;
+    // [Space(20)]
+    // [Header("= Dagger =")]
+    // [SerializeField] float lungeDist = .2f;
 
     protected override void AttackCheckClose()
     {
         if(combat.altAttacking) return; //Check if attack is already started, this prevents Manualflip being called during attack coroutine
-        // if (!PlatformCheck() || isRangedAttack) return;
         if (!PlatformCheck()) return;
 
-        // if (raycast.playerInRangeClose)
-        // {
-        //     combat.altAttacking = true;
-        //     // StartCoroutine(LungeAttack());
-        // }
-        // else
-        // {
-        //     combat.altAttacking = true;
-        //     combat.AttackFar();
-        // }
-
+    
         if (raycast.playerInRangeClose)
         {
-            combat.altAttacking = true;
-            Debug.Log("player close");
             combat.AttackClose();
         }
     }
 
+    protected override void AttackCheckFar()
+    {
+        if(combat.altAttacking) return;
+        if(!combat.CanAttackFar()) return; //Check if a far attack behavior is null
+        //Player isn't on the same platform, and enemy doesn't have range
+        if (!PlatformCheck() && !isRangedAttack) return;
+    }
     
 }

--- a/_Enemy Scripts/Tier 2 Enemies/Dagger_EnemyController.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Dagger_EnemyController.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Dagger_EnemyController : Base_EnemyController
+{
+    [Space(20)]
+    [Header("= Dagger =")]
+    [SerializeField] float lungeDist = .2f;
+
+    protected override void AttackCheckClose()
+    {
+        if(combat.altAttacking) return; //Check if attack is already started, this prevents Manualflip being called during attack coroutine
+        // if (!PlatformCheck() || isRangedAttack) return;
+        if (!PlatformCheck()) return;
+
+        // if (raycast.playerInRangeClose)
+        // {
+        //     combat.altAttacking = true;
+        //     // StartCoroutine(LungeAttack());
+        // }
+        // else
+        // {
+        //     combat.altAttacking = true;
+        //     combat.AttackFar();
+        // }
+
+        if (raycast.playerInRangeClose)
+        {
+            combat.altAttacking = true;
+            Debug.Log("player close");
+            combat.AttackClose();
+        }
+    }
+
+    
+}

--- a/_Enemy Scripts/Tier 2 Enemies/Dagger_EnemyController.cs.meta
+++ b/_Enemy Scripts/Tier 2 Enemies/Dagger_EnemyController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2612090874a4f9e49b5d53cd6e353852
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -376,7 +376,7 @@ public class Base_PlayerCombat : MonoBehaviour
             if (attackPoints[currAttackIndex] == null) return;
 
             Gizmos.DrawWireCube(attackPoints[currAttackIndex].position, 
-                new Vector3((hitBoxLength[currAttackIndex]),
+                new Vector3(hitBoxLength[currAttackIndex],
                 hitBoxHeight[currAttackIndex], 0));
             
             Gizmos.DrawWireCube(parryPoint.position, new Vector3(parryHitBoxLength, parryHitboxHeight, 0));

--- a/_Player Scripts/Base_PlayerMovement.cs
+++ b/_Player Scripts/Base_PlayerMovement.cs
@@ -22,6 +22,8 @@ public class Base_PlayerMovement : MonoBehaviour
     [Header("Current Platform")]
     public int currPlatform;
     private bool updatePlatform;
+    [SerializeField] protected float updatingPlatformTimer;
+
 
     [Space(10)]
 
@@ -186,7 +188,7 @@ public class Base_PlayerMovement : MonoBehaviour
             }
             canDoubleJump = false;
             doubleJumped = false;
-            if (updatePlatform) CheckPlatform();
+            CheckPlatform();
             CheckRunVFX();
         }
         else
@@ -194,6 +196,7 @@ public class Base_PlayerMovement : MonoBehaviour
             //Not grounded, allow CheckPlatform() to get platform ID once
             runTimer = 0;
             updatePlatform = true;
+            updatingPlatformTimer = 2;
             canDoubleJump = true;
         }
     }
@@ -383,11 +386,16 @@ public class Base_PlayerMovement : MonoBehaviour
     void CheckPlatform()
     {
         //Only updating platform after IsGrounded() returns false, then update once
-        //if (!updatePlatform) return;
+        if (!updatePlatform) return;
+
+        if(updatingPlatformTimer > 0)
+        {
+            updatingPlatformTimer -= Time.deltaTime;
+        }
+        else updatePlatform = false;
 
         int i = Physics2D.OverlapCircle(groundCheck.position, 0.01f, groundLayer).GetInstanceID();
         if (i != currPlatform) currPlatform = i;
-        updatePlatform = false;
         // string j = Physics2D.OverlapCircle(groundCheck.position, 0.01f, groundLayer).name;
         // Debug.Log("Current Platform: " + j);
     }


### PR DESCRIPTION
### Enemies
- Updated Enemy controllers to change behavior when aggroed
- Updated Lunge and fixed movement variable overlap
- **Archer**
  - Fix for Lunge reset
  - Offset raycast positioning for detecting closer ranges
  - Removed visual beam charge for Archer projectile
    - 4 frame charge up beam was too confusing when determining the hit time
- **Dagger**
  - First attack lunges at Player and attacks twice
  - Second attack is a fast swipe with a longer range

### Misc
- Fixed PlatformCheck returning the wrong platform ID
  - PlatformCheck now continuously checks for a new platform ID for 2 seconds after leaving the ground
  - Timer resets after leaving the ground again
- Fixed bugs with enemy aggro causing overlapping movement behavior