### PR TITLE
Heal and Blood Augment shops

### DIFF
--- a/DEBUGGING_MODE.cs
+++ b/DEBUGGING_MODE.cs
@@ -54,7 +54,7 @@ public class DEBUGGING_MODE : MonoBehaviour
                 // damageable.TakeDamage(damage);
                 damageable.TakeDamageStatus(damage);
                 ScreenShakeListener.Instance.Shake(3);
-                Transform enemyHitOffset = damageable.GetPosition();
+                Transform enemyHitOffset = damageable.GetHitPosition();
 
                 // if(statusEffectPrefab != null)
                 // {

--- a/_Augments/Alternate Shops.meta
+++ b/_Augments/Alternate Shops.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e9f46ee6894ebe47b0105f1289a96e2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs
+++ b/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs
@@ -1,0 +1,89 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AugmentDisplay_HealOnly : AugmentDisplay
+{
+    [Header("- Heal Shop Only -")]
+    [SerializeField] protected float healAmountLower = 10;
+    [SerializeField] protected float healAmountUpper = 30;
+    [SerializeField] string healItemName = "";
+    [SerializeField] Sprite healIcon;
+    [SerializeField] float healAmount;
+
+    public override void RefreshInfo()
+    {
+        healAmount = RandomHealAmount();
+
+        DisplayName.text = healItemName;
+        AugmentIcon_Image.sprite = healIcon;
+        DisplayDescription.text = "Heal " + healAmount.ToString("N0") + " HP";
+
+        Price = (int)healAmount;
+        
+        if(PriceDisplay != null)
+        {
+            if(selectMenu.bloodShop)
+            {
+                PriceDisplay.text = "-" + Price.ToString() + " HP";
+            }
+            else
+            {
+                PriceDisplay.text = Price.ToString();
+            }
+        }
+
+        // GetBorderColor();
+        Border_Image.color = Color.green;
+    }
+
+    private float RandomHealAmount()
+    {
+        float healAmount; //1-5
+        // float rand = Random.Range(0f, 1.0f);
+        float rand = Random.value;
+
+        // Debug.Log("Random Level: " + rand);
+        
+        // if(rand >= .50f) augmentLevel = 1; //- 50%
+        // else if(rand >= .20f) augmentLevel = 2; //- 30%
+        // else if(rand >= .04f) augmentLevel = 3; //- 16%
+        // else if(rand >= .01f) augmentLevel = 4; //- 3%
+        // else augmentLevel = 5; //- 1%
+        //
+        if(rand <= .02f) healAmount = 50; //- 2%
+        else if(rand <= .09f) healAmount = 40; //- 7%
+        else if(rand <= .25f) healAmount = 30; //- 16%
+        else if(rand <= .55f) healAmount = 20; //- 30%
+        else healAmount = 15; //- 50%
+
+        return healAmount;
+    }
+
+    public override void SelectAugment()
+    {
+        if(!allowInput) return;
+        if(selectMenu.isShop)
+        {
+            //Take player health if blood Shop, else take gold
+            if(selectMenu.bloodShop)
+            {
+                if(Price > GameManager.Instance.PlayerCombat.currentHP) return;
+                GameManager.Instance.PlayerCombat.TakeDamage(Price);
+            }
+            else
+            {
+                if(Price > GameManager.Instance.Inventory.goldAmount) return; //Player can't afford
+                GameManager.Instance.Inventory.UpdateGold(-Price); //Take gold from player, update display
+            }
+        }
+
+        GameManager.Instance.PlayerCombat.HealPlayer(healAmount);
+
+        allowInput = false;
+        // selectMenu.SelectAugment(augmentScript, randomizeLevel);
+        ToggleOverlay(true);
+        selectMenu.CloseSelectMenu();
+    }
+
+}

--- a/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs.meta
+++ b/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb6441d8a4611e246941de847d308297
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/Alternate Shops/AugmentSelectMenu_Blood.cs
+++ b/_Augments/Alternate Shops/AugmentSelectMenu_Blood.cs
@@ -60,7 +60,6 @@ public class AugmentSelectMenu_Blood : AugmentSelectMenu
             default: break;
         }
 
-        Debug.Log("Health cost: " + totalHealthCost);
         return totalHealthCost;
     }
 }

--- a/_Augments/Alternate Shops/AugmentSelectMenu_Blood.cs
+++ b/_Augments/Alternate Shops/AugmentSelectMenu_Blood.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+
+public class AugmentSelectMenu_Blood : AugmentSelectMenu
+{
+    
+    public override void SelectAugment(AugmentScript augment, bool randomizeLevel)
+    {
+        if(!allowInput) return;
+        if(augmentInventory == null) augmentInventory = GameManager.Instance.AugmentInventory;
+        // int chosenIndex = augmentsInStock.IndexOf(augment);
+
+        if(pool == null) pool = GameManager.Instance.AugmentPool;
+
+        //Get Random level if it is a duplicate Augment
+        if(randomizeLevel) pool.RandomizeAugmentStats(augment, true);
+        
+        pool.ChooseAugment(augment); //Randomize augment before adding
+
+        //Disable input for selecting Augments
+        for(int i=0; i<totalAugments; i++) menuSlots[i].allowInput = false;
+
+        // UpdateDisplay(true); //Updates price colors if player buys something //*Only need this if allowing multiple purchases
+
+        //Disable inputs to close the Menu after one Augment was selected
+        allowInput = false;
+        augmentSelected = true;
+
+        if(shopController != null)
+            shopController.oneTimePurchaseDone = true;
+
+        StartCoroutine(DisableSelectMenu(.5f));
+    }
+
+    protected override int GetPrice(AugmentScript augment)
+    {
+        int totalHealthCost = 0;
+
+        switch(augment.Tier)
+        {
+            case 0: totalHealthCost = 2; break;
+            case 1: totalHealthCost = 4; break;
+            case 2: totalHealthCost = 6; break;
+            case 3: totalHealthCost = 8; break;
+            case 4: totalHealthCost = 10; break;
+            case 5: totalHealthCost = 12; break;
+            default: totalHealthCost = 0; break;
+        }
+
+        switch(augment.AugmentLevel)
+        {
+            case 0: totalHealthCost += 1; break;
+            case 1: totalHealthCost += 2; break;
+            case 2: totalHealthCost += 3; break;
+            case 3: totalHealthCost += 4; break;
+            case 4: totalHealthCost += 5; break;
+            case 5: totalHealthCost += 6; break;
+            default: break;
+        }
+
+        Debug.Log("Health cost: " + totalHealthCost);
+        return totalHealthCost;
+    }
+}

--- a/_Augments/Alternate Shops/AugmentSelectMenu_Blood.cs.meta
+++ b/_Augments/Alternate Shops/AugmentSelectMenu_Blood.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74ed8134766cd4f4ebdb971e8c034772
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/Alternate Shops/AugmentSelectMenu_Heal.cs
+++ b/_Augments/Alternate Shops/AugmentSelectMenu_Heal.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AugmentSelectMenu_Heal : AugmentSelectMenu
+{
+    
+    //Always have Heal in first Menu slot
+    
+}

--- a/_Augments/Alternate Shops/AugmentSelectMenu_Heal.cs.meta
+++ b/_Augments/Alternate Shops/AugmentSelectMenu_Heal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5925dc0a795a0e04cbe7c5a51257dd19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/Augment.cs
+++ b/_Augments/Augment.cs
@@ -9,7 +9,7 @@ public class Augment : ScriptableObject
     public int AugmentID;
     // public Color32 TierColor;
 
-    public enum _Tier { Common, Rare, Epic, Legendary, Overcharged, Unstable };
+    public enum _Tier { Common, Rare, Epic, Legendary, Unstable };
     // public int Tier = 0; //0: Common, 1: Rare, 2: Epic, 3: Legendary, 4: Overcharged, 5: Unstable
     public _Tier Tier; //0: Common, 1: Rare, 2: Epic, 3: Legendary, 4: Overcharged, 5: Unstable
     // public int MaxLevel = 5; 

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -7,16 +7,16 @@ using TMPro;
 public class AugmentDisplay : MonoBehaviour
 {
     [SerializeField] public AugmentScript augmentScript;
-    [SerializeField] private AugmentSelectMenu selectMenu;
+    [SerializeField] protected AugmentSelectMenu selectMenu;
     public bool allowInput;
 
     [Space(10)]
     [Header("Display Toggles")]
-    [SerializeField] bool inInventory = false;
-    [SerializeField] GameObject selectedOverlay;
-    [SerializeField] private TextMeshProUGUI selectedOverlayText;
-    [SerializeField] private GameObject ownedText;
-    [SerializeField] GameObject FullDisplayParent;
+    [SerializeField] protected bool inInventory = false;
+    [SerializeField] protected GameObject selectedOverlay;
+    [SerializeField] protected TextMeshProUGUI selectedOverlayText;
+    [SerializeField] protected GameObject ownedText;
+    [SerializeField] protected GameObject FullDisplayParent;
 
     [Space(10)]
     [Header("== Needed Setup ==")]
@@ -27,7 +27,7 @@ public class AugmentDisplay : MonoBehaviour
     [SerializeField] public bool alwaysDisplay = false;
     [Space(10)]
     [Header("Display on Hover")]
-    [SerializeField] GameObject ToggleDescParent;
+    [SerializeField] protected GameObject ToggleDescParent;
     [SerializeField] public TextMeshProUGUI DisplayName;
     [SerializeField] public TextMeshProUGUI DisplayDescription;
     [SerializeField] public TextMeshProUGUI DisplayLevel;
@@ -35,13 +35,13 @@ public class AugmentDisplay : MonoBehaviour
     [Header("Price")]
     [SerializeField] public TextMeshProUGUI PriceDisplay;
     [SerializeField] public int Price;
-    private Button button;
+    protected Button button;
     
     [Header("Duplicate")]
-    [SerializeField] private bool randomizeLevel = false;
+    [SerializeField] protected bool randomizeLevel = false;
     [SerializeField] public bool upgradeShop = false;
 
-    void Start()
+    protected void Start()
     {
         randomizeLevel = false;
         if(augmentScript == null)
@@ -57,7 +57,7 @@ public class AugmentDisplay : MonoBehaviour
         if(ownedText != null) ownedText.SetActive(false);
     }
 
-    void OnEnable()
+    protected void OnEnable()
     {
         if(selectMenu == null) selectMenu = GetComponentInParent<AugmentSelectMenu>();
         RefreshInfo();
@@ -86,7 +86,7 @@ public class AugmentDisplay : MonoBehaviour
         selectedOverlayText.text = overlayText;
     }
 
-    IEnumerator RevealAugment()
+    protected IEnumerator RevealAugment()
     {
         allowInput = false;
         // yield return new WaitForSecondsRealtime(.2f);
@@ -132,7 +132,7 @@ public class AugmentDisplay : MonoBehaviour
         }
     }
 
-    public void SelectAugment()
+    public virtual void SelectAugment()
     {
         if(!allowInput) return;
         if(selectMenu.isShop)
@@ -140,7 +140,7 @@ public class AugmentDisplay : MonoBehaviour
             //Take player health if blood Shop, else take gold
             if(selectMenu.bloodShop)
             {
-                if(Price > GameManager.Instance.PlayerCombat.currentHP) return;
+                if(Price >= GameManager.Instance.PlayerCombat.currentHP) return;
                 GameManager.Instance.PlayerCombat.TakeDamage(Price);
             }
             else
@@ -155,7 +155,7 @@ public class AugmentDisplay : MonoBehaviour
         ToggleOverlay(true);
     }
 
-    public void RefreshInfo()
+    public virtual void RefreshInfo()
     {
         if(augmentScript == null) return;
 
@@ -274,7 +274,7 @@ public class AugmentDisplay : MonoBehaviour
         FullDisplayParent.SetActive(toggle);
     }
 
-    private void GetBorderColor()
+    protected void GetBorderColor()
     {
         switch(augmentScript.Tier)
         {

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -270,10 +270,7 @@ public class AugmentDisplay : MonoBehaviour
             case 3: //Legendary
                 Border_Image.color = new Color(1, 0.4445357f, 0.1745283f); //Orange
                 break;
-            case 4: //Overcharged
-                Border_Image.color = Color.cyan;
-                break;
-            case 5: //Unstable
+            case 4: //Unstable
                 Border_Image.color = Color.red;
                 break;
             default:

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -137,8 +137,17 @@ public class AugmentDisplay : MonoBehaviour
         if(!allowInput) return;
         if(selectMenu.isShop)
         {
-            if(Price > GameManager.Instance.Inventory.goldAmount) return; //Player can't afford
-            GameManager.Instance.Inventory.UpdateGold(-Price); //Take gold from player, update display
+            //Take player health if blood Shop, else take gold
+            if(selectMenu.bloodShop)
+            {
+                if(Price > GameManager.Instance.PlayerCombat.currentHP) return;
+                GameManager.Instance.PlayerCombat.TakeDamage(Price);
+            }
+            else
+            {
+                if(Price > GameManager.Instance.Inventory.goldAmount) return; //Player can't afford
+                GameManager.Instance.Inventory.UpdateGold(-Price); //Take gold from player, update display
+            }
         }
 
         allowInput = false;
@@ -216,7 +225,18 @@ public class AugmentDisplay : MonoBehaviour
         }
         else DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
         
-        if(PriceDisplay != null) PriceDisplay.text = Price.ToString();
+        if(PriceDisplay != null)
+        {
+            if(selectMenu.bloodShop)
+            {
+                PriceDisplay.text = "-" + Price.ToString() + " HP";
+            }
+            else
+            {
+                PriceDisplay.text = Price.ToString();
+            }
+        }
+
         GetBorderColor();
     }
 

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -11,7 +11,7 @@ public class AugmentPool : MonoBehaviour
     public int totalOwnedAugments;
 
     [Header("Augment Lists by Tier")]
-    public AugmentPoolHelper[] augmentPoolHelpers; //Tiers 0, 1, 2, 3, 4, 5
+    public AugmentPoolHelper[] augmentPoolHelpers; //Tiers 0, 1, 2, 3, 4
     
     [Header("Augment Lists")]
     public List<AugmentScript> ownedAugments; //picked augments and can be pulled from with a higher level
@@ -214,12 +214,7 @@ public class AugmentPool : MonoBehaviour
         /////////////////////////////////////////////////////////
 
 
-        if(rand <= .02f){ //Overcharged or Unstable - 2%
-            // rand = Random.Range(0f, 1.0f);
-            rand = Random.value;
-            if(rand < .5f) augmentTier = 4; 
-            else augmentTier = 5; 
-        }
+        if(rand <= .02f) augmentTier = 4; //Unstable - 2%
         else if(rand <= .06f) augmentTier = 3; //Legendary - 4%
         else if(rand <= .20f) augmentTier = 2; //Epic - 14%
         else if(rand <= .50f) augmentTier = 1; //Rare - 30%

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -63,6 +63,7 @@ public class AugmentScript : MonoBehaviour
         if(augmentScrObj == null) { Debug.Log("No Augment Scriptable Object referenced!"); return; }
         Name = augmentScrObj.Name;
         Icon_Image = augmentScrObj.AugmentIcon;
+        Tier = (int)augmentScrObj.Tier;
 
         //
         baseDescription = augmentScrObj.Description;

--- a/_Augments/AugmentSelectMenu.cs
+++ b/_Augments/AugmentSelectMenu.cs
@@ -162,6 +162,12 @@ public class AugmentSelectMenu : MonoBehaviour
         StartCoroutine(DisableSelectMenu(.5f));
     }
 
+    public void CloseSelectMenu(float delay = .5f)
+    {
+        //For external calls
+        StartCoroutine(DisableSelectMenu(delay));
+    }
+
     protected IEnumerator DisableSelectMenu(float delay)
     {
         yield return new WaitForSecondsRealtime(delay);
@@ -186,7 +192,7 @@ public class AugmentSelectMenu : MonoBehaviour
                 //Price is red if Player can't afford
                 if(bloodShop)
                 {
-                    if(prices[i] > GameManager.Instance.PlayerCombat.currentHP + 1)
+                    if(prices[i] >= (int)GameManager.Instance.PlayerCombat.currentHP)
                         currAugSlot.UpdateColor(false);
                     else
                         currAugSlot.UpdateColor(true);

--- a/_Enemy Scripts/Base_BossCombat.cs
+++ b/_Enemy Scripts/Base_BossCombat.cs
@@ -456,9 +456,15 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         TakeDamage(damageTaken);
     }
 
-    public virtual Transform GetPosition()
+    public virtual Transform GetHitPosition()
     {
         return hitEffectsOffset;
+    }
+
+    public virtual Transform GetGroundPosition()
+    {
+        return transform;
+        // return bottomOffset;
     }
 
     protected void HitFlash(float resetDelay = .1f)

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -482,9 +482,15 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         TakeDamage(damageTaken, false);
     }
 
-    public virtual Transform GetPosition()
+    public virtual Transform GetHitPosition()
     {
         return hitEffectsOffset;
+    }
+
+    public virtual Transform GetGroundPosition()
+    {
+        // return transform;
+        return bottomOffset;
     }
 
     public virtual void PlayIndicator()
@@ -528,7 +534,7 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
 
         //Base_EnemyAnimator checks for isAlive to play Death animation
         isAlive = false;
-        GameManager.Instance.AugmentInventory.OnKill(transform);
+        GameManager.Instance.AugmentInventory.OnKill(hitEffectsOffset);
         if(enemyStageManager != null) enemyStageManager.UpdateEnemyCount();
 
         //Disable sprite renderer before deleting gameobject

--- a/_Enemy Scripts/Enemy Behaviors/Ranged_Global.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Ranged_Global.cs
@@ -35,13 +35,14 @@ public class Ranged_Global : Ranged_Horizontal
 
 
         combat.PlayIndicator(); //---------------------------
+        Vector3 playerPos = GetPlayerPosX(); //Only get player position here
+        
         yield return new WaitForSeconds(chargeUpAnimDelay); //Charge up portion of animation
 
         combat.animator.PlayManualAnim(0, fullAnimTime);
 
         PlayIndicatorExplode();
 
-        Vector3 playerPos = GetPlayerPosX();
         //Instantiate projectile, set variables from this script
         GameObject projectileObj = Instantiate(globalProjectile, playerPos, transform.rotation);
         CastExplosion script = projectileObj.GetComponent<CastExplosion>();

--- a/_Interfaces/InterfaceDefinitions.cs
+++ b/_Interfaces/InterfaceDefinitions.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 
 public interface IDamageable
 {
-    Transform GetPosition();
+    Transform GetHitPosition();
+    Transform GetGroundPosition();
     void TakeDamage(float damageTaken, bool knockback = false, float strength = 8, float xPos = 0);
     void TakeDamageStatus(float damageTaken);
 }

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -354,7 +354,7 @@ public class Base_PlayerCombat : MonoBehaviour
         //float blockDuration;
 
         // blockAnimTime
-        yield return new WaitForSeconds(blockDelay); //0.0834f\
+        yield return new WaitForSeconds(blockDelay + blockDelayAnimTime); //0.0834f\
         isParrying = true;
         yield return new WaitForSeconds(blockDuration);
         isParrying = false;

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -286,7 +286,7 @@ public class Base_PlayerCombat : MonoBehaviour
             if(damageable != null)
             {
                 damageable.TakeDamage(damageDealt, true, knockbackStrength, transform.position.x);
-                Transform enemyPos = damageable.GetPosition();
+                Transform enemyPos = damageable.GetHitPosition();
                 augmentInventory.OnHit(enemyPos);
                 HitStopAnim(attackAnimFull, groundAttack);
 
@@ -313,7 +313,7 @@ public class Base_PlayerCombat : MonoBehaviour
             {
                 // damageable.TakeDamage(1, true, knockbackStrength, transform.position.x);
                 damageable.TakeDamageStatus(1);
-                Transform enemyPos = damageable.GetPosition();
+                Transform enemyPos = damageable.GetHitPosition();
                 augmentInventory.OnParry(enemyPos);
                 // InstantiateManager.Instance.ParryEffects.ShowHitEffect(parryPoint.position, transform.localScale.x);
 

--- a/_Player Scripts/Base_PlayerMovement.cs
+++ b/_Player Scripts/Base_PlayerMovement.cs
@@ -258,16 +258,13 @@ public class Base_PlayerMovement : MonoBehaviour
     #region Drop-through Platform
     private void OnCollisionEnter2D(Collision2D collision)
     {
-        /*if(collision.gameObject.CompareTag("SolidPlatform"))
-        {
-            currentOneWayPlatform = null;
-        }*/
-
         if (collision.gameObject.CompareTag("OneWayPlatform"))
         {
             currentOneWayPlatform = collision.gameObject;
             canDropThrough = true;
         }
+
+        // ManualPlatformCheck(collision);
     }
 
     private void OnCollisionExit2D(Collision2D collision)
@@ -276,6 +273,15 @@ public class Base_PlayerMovement : MonoBehaviour
         {
             currentOneWayPlatform = null;
             canDropThrough = false;
+        }
+    }
+
+    public void ManualPlatformCheck(Collision2D collision)
+    {
+        if (collision.gameObject.CompareTag("OneWayPlatform"))
+        {
+            currentOneWayPlatform = collision.gameObject;
+            canDropThrough = true;
         }
     }
 

--- a/_Status Effects/Base_AoE_Explosion.cs
+++ b/_Status Effects/Base_AoE_Explosion.cs
@@ -49,7 +49,8 @@ public class Base_AoE_Explosion : MonoBehaviour
             {
                 damageable.TakeDamage(damage, true, knockbackStrength);
                 ScreenShakeListener.Instance.Shake(2);
-                Transform enemyHitOffset = damageable.GetPosition();
+                // Transform enemyHitOffset = damageable.GetPosition();
+                Transform enemyHitOffset = damageable.GetGroundPosition();
 
                 if(statusEffectPrefab != null)
                 {


### PR DESCRIPTION
### New Shops
- **Blood Shop**
  - Player can purchase Augments with Health
  - Player can only purchase if they have at least 1 more Health than the price
  - Updated currency icon
- **Heal Shop**
  - First menu slot is now a heal, with a randomized value and price
  - Remaining slots are rolled as normal augments

### Enemy Changes
- Removed lunge from Flower enemy
- Lowered enemy attack frequency
- Updated Drone explosion with a more visible indicator, and only tracks the Player at the initial charge

### Augment Changes
- Removed Overcharged augments, now 5 total Augment Tiers
  - Updated Augment scriptable object and Display scripts
- Re-arranged certain augments to different Tiers

### Misc
- Adjusted Parry timing
- Replaced explosion and fire animations for Combustion augment effect