### PR TITLE
More Augments, Enemy updates

### DIFF
--- a/CastExplosion.cs
+++ b/CastExplosion.cs
@@ -19,6 +19,16 @@ public class CastExplosion : MonoBehaviour
     [Header("Adjustable Variables")]
     [SerializeField] int screenshakeIntensity = 1;
     [SerializeField] float startDelay = 0;
+
+    [Header("(optional) Move to Ground")]
+    [SerializeField] bool moveToGround = false;
+    [SerializeField] Transform optionalRaycast;
+    [SerializeField] float groundCheckDist = 1;
+    [SerializeField] LayerMask groundLayer;
+    private bool checkForGround = false;
+
+    [Space(10)]
+
     [Header("Knockback")]
     public bool hasKnockBack = true;
     [SerializeField] float knockbackStrength = 2f;
@@ -46,6 +56,7 @@ public class CastExplosion : MonoBehaviour
         if (animChargeUp == null) animChargeUp = GetComponentInChildren<Animator>();
         if (animExplosion == null) animExplosion = GetComponent<Animator>();
         if (TOGGLE) gameObject.SetActive(false);
+        checkForGround = false;
     }
 
     void Start()
@@ -56,12 +67,45 @@ public class CastExplosion : MonoBehaviour
 
     void OnEnable()
     {
+        // if(moveToGround) checkForGround = true;
+
         // if (TOGGLE) StartCoroutine(PlayAnims());
         StartCoroutine(PlayAnims());
     }
 
+    void Update()
+    {
+        if(checkForGround)
+        {
+            GetGround();
+            DebugDrawRaycast();
+        }
+    }
+
+    private void GetGround()
+    {
+        RaycastHit2D hit = Physics2D.Raycast(optionalRaycast.position, Vector2.down, groundCheckDist, groundLayer);
+        if(hit.collider != null)
+        {
+            checkForGround = false;
+            transform.position = hit.point;
+        }
+    }
+
+    void DebugDrawRaycast()
+    {
+        Vector3 down = transform.TransformDirection(Vector3.down) * groundCheckDist;
+        Debug.DrawRay(optionalRaycast.position, down, Color.red);
+    }
+
     IEnumerator PlayAnims()
     {
+        if(moveToGround) 
+        {
+            yield return new WaitForSeconds(.02f);
+            checkForGround = true;
+        }
+
         yield return new WaitForSeconds(startDelay);
 
         if(animChargeUp != null) //Skip this delay if no ChargeUp

--- a/DEBUGGING_MODE.cs
+++ b/DEBUGGING_MODE.cs
@@ -52,7 +52,7 @@ public class DEBUGGING_MODE : MonoBehaviour
             if(damageable != null)
             {
                 // damageable.TakeDamage(damage);
-                damageable.TakeDamageStatus(damage);
+                damageable.TakeDamageStatus(damage, 3);
                 ScreenShakeListener.Instance.Shake(3);
                 Transform enemyHitOffset = damageable.GetHitPosition();
 

--- a/_Augments/Augment.cs
+++ b/_Augments/Augment.cs
@@ -38,7 +38,6 @@ public class Augment : ScriptableObject
         Attack, Attack_Speed, 
         Crit_Chance, Crit_Multiplier };
     public _BuffedStat BuffedStat;
-    //TODO: figure out how to buff the specified player stat//needs testing, might work
     
     [Header("= Debuffed Stats =")]
     public float StatDecrease;
@@ -50,10 +49,17 @@ public class Augment : ScriptableObject
         CritChance, CritMultiplier };
     public _DebuffedStat DebuffedStat;
 
+    [Header("= Conditional Augments =")]
+    public bool isConditional;
+    // [Range(0.01f, 1.0f)]
+    [Header("[0.01  -  1.0]")]
+    public float procChance;
+    // [Range(0.01f, 1.0f)]
+    public float procChancePerLevel;
+
     // [Space(10)]
     // [Header("== Conditional Augments (Only AugmentType != 0) ==")]
     // public float conditionalBuffAmount;
-
 
 
 

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -18,6 +18,11 @@ public class AugmentDisplay : MonoBehaviour
     [SerializeField] protected GameObject ownedText;
     [SerializeField] protected GameObject FullDisplayParent;
 
+    [Header("Augment Status Display")]
+    [SerializeField] protected GameObject timerParent;
+    [SerializeField] protected TextMeshProUGUI timerDisplay;
+    [SerializeField] float timer;
+
     [Space(10)]
     [Header("== Needed Setup ==")]
     [Header("Icons")]
@@ -55,6 +60,9 @@ public class AugmentDisplay : MonoBehaviour
         else ToggleDescriptionDisplay(true);
 
         if(ownedText != null) ownedText.SetActive(false);
+        if(timerParent != null) timerParent.SetActive(false);
+
+        timer = 0;
     }
 
     protected void OnEnable()
@@ -65,6 +73,21 @@ public class AugmentDisplay : MonoBehaviour
         if(selectedOverlayText == null && selectedOverlay != null) selectedOverlayText = selectedOverlay.GetComponentInChildren<TextMeshProUGUI>();
 
         StartCoroutine(RevealAugment());
+    }
+
+    void Update()
+    {
+        if(timerParent == null || timerDisplay == null) return;
+
+        if(timer > 0)
+        {
+            timer -= Time.deltaTime;
+            timerDisplay.text = timer.ToString("N1") + "s";
+        }
+        else
+        {
+            timerParent.SetActive(false);
+        }
     }
     
     public void ToggleOverlay(bool toggle, bool maxLevel = false)
@@ -141,7 +164,8 @@ public class AugmentDisplay : MonoBehaviour
             if(selectMenu.bloodShop)
             {
                 if(Price >= GameManager.Instance.PlayerCombat.currentHP) return;
-                GameManager.Instance.PlayerCombat.TakeDamage(Price);
+                GameManager.Instance.PlayerCombat.TakeTrueDamage(Price);
+                // GameManager.Instance.PlayerCombat.TakeDamage(Price);
             }
             else
             {
@@ -296,5 +320,14 @@ public class AugmentDisplay : MonoBehaviour
             default:
                 break;
         }
+    }
+
+    public void ToggleAugmentStatus(bool toggle, float timerDuration)
+    {
+        if(timerParent == null) return;
+
+        //Toggle timer display and start timer
+        timerParent.SetActive(toggle);
+        if(toggle) timer = timerDuration;
     }
 }

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -244,7 +244,6 @@ public class AugmentDisplay : MonoBehaviour
                 }
             }
 
-
             ToggleOverlay(toggleOverlay, isMaxLevel); //maxLevel false | "Purchased" overlay
         }
         else DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
@@ -268,6 +267,7 @@ public class AugmentDisplay : MonoBehaviour
     {
         if(augmentScript == null) return;
 
+        RefreshInfo();
         DisplayName.text = augmentScript.Name;
         AugmentIcon_Image.sprite = augmentScript.Icon_Image;
         DisplayDescription.text = augmentScript.Description;

--- a/_Augments/AugmentInventory.cs
+++ b/_Augments/AugmentInventory.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class AugmentInventory : MonoBehaviour
 {
     [Header("References")]
-    [SerializeField] AugmentInventoryDisplay augmentInventoryDisplay;
+    [SerializeField] public AugmentInventoryDisplay augmentInventoryDisplay;
     [SerializeField] Base_PlayerCombat combat;
     [SerializeField] Base_PlayerMovement movement;
     [Header("====== BASE STATS ======")]
@@ -38,6 +38,7 @@ public class AugmentInventory : MonoBehaviour
 
     [Header("Augments")]
     [SerializeField] private List<AugmentScript> heldAugments;
+    [SerializeField] private List<AugmentDisplay> heldAugmentDisplays;
 
     [Header("Conditional Augments")]
     [SerializeField] private List<Base_ConditionalAugments> onKillAugments;
@@ -49,6 +50,7 @@ public class AugmentInventory : MonoBehaviour
     void Awake()
     {
         heldAugments = new List<AugmentScript>();
+        heldAugmentDisplays = new List<AugmentDisplay>();
         
         if(combat == null) combat = GetComponentInParent<Base_PlayerCombat>();
         if(movement == null) movement = GetComponentInParent<Base_PlayerMovement>();
@@ -133,6 +135,7 @@ public class AugmentInventory : MonoBehaviour
             default: break;
         }
     }
+
 #endregion
 
 #region Stat Managers
@@ -227,6 +230,10 @@ public class AugmentInventory : MonoBehaviour
             return;
         }
         heldAugments.Add(augment);
+
+        AugmentDisplay currDisplay = augment.GetComponent<AugmentDisplay>();
+        heldAugmentDisplays.Add(currDisplay);
+
         if(augmentInventoryDisplay != null) augmentInventoryDisplay.AddAugmentToDisplay(heldAugments);
         UpdateAugments();
     }
@@ -234,6 +241,10 @@ public class AugmentInventory : MonoBehaviour
     public void RemoveAugment(AugmentScript augment)
     {
         heldAugments.Remove(augment);
+
+        AugmentDisplay currDisplay = augment.GetComponent<AugmentDisplay>();
+        heldAugmentDisplays.Remove(currDisplay);
+        
         RemoveAugmentStats(augment);
         ResetModifiedStats();
         

--- a/_Augments/AugmentInventoryDisplay.cs
+++ b/_Augments/AugmentInventoryDisplay.cs
@@ -20,6 +20,7 @@ public class AugmentInventoryDisplay : MonoBehaviour
         for(int i=0; i<numSlots; i++)
         {
             AugmentSlots[i].augmentScript = augmentList[i];
+            augmentList[i].displayedIndex = i; //Set index value for reference
         }
 
         ToggleSlots();
@@ -34,5 +35,11 @@ public class AugmentInventoryDisplay : MonoBehaviour
             if(augSlot.augmentScript != null) AugmentSlots[i].gameObject.SetActive(true);
             else AugmentSlots[i].gameObject.SetActive(false);
         }
+    }
+
+    public void ToggleAugmentStatus(int currIdx, float timerDuration)
+    {
+        //Get Augment index in displayed Augments
+        AugmentSlots[currIdx].ToggleAugmentStatus(true, timerDuration);
     }
 }

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -25,6 +25,7 @@ public class AugmentScript : MonoBehaviour
     public int DebuffedStat;
     public float debuffedAmount; //TODO: might not use, just use a negative value for buffedAmount
     public float debuffedAmountPercent; //TODO: might not use, just use a negative value for buffedAmount
+    public int displayedIndex = 0;
 
     // [Header("Conditional Stats")]
     // public float conditionalBuffedAmount;

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -25,6 +25,9 @@ public class AugmentScript : MonoBehaviour
     public int DebuffedStat;
     public float debuffedAmount; //TODO: might not use, just use a negative value for buffedAmount
     public float debuffedAmountPercent; //TODO: might not use, just use a negative value for buffedAmount
+    [Space(10)]
+    public bool isConditional;
+    public float procChance;
     public int displayedIndex = 0;
 
     // [Header("Conditional Stats")]
@@ -81,6 +84,9 @@ public class AugmentScript : MonoBehaviour
 
         baseBuffedAmount = buffedAmount;
         baseBuffedAmountPercent = buffedAmountPercent;
+
+        isConditional = augmentScrObj.isConditional;
+        procChance = augmentScrObj.procChance;
         // baseBuffedAmountPercent = 
         // DebuffedStat = augmentScrObj. //TODO: might just use "modifiedStat", then use + or - for changes
         UpdateConditional();
@@ -90,10 +96,12 @@ public class AugmentScript : MonoBehaviour
 //
     private void UpdateConditional()
     {
-        //TODO: need to test update with UpdateStatsToLevel()
         if(ConditionalAugmentScript == null) return;
         // ConditionalAugmentScript.buffAmount = buffedAmount;
         // ConditionalAugmentScript.buffAmountPercent = buffedAmountPercent;
+
+        //Update proc chance with current level
+        procChance = augmentScrObj.procChance + ((AugmentLevel - 1) * augmentScrObj.procChancePerLevel);
         ConditionalAugmentScript.UpdateLevelStats();
     }
 
@@ -130,7 +138,7 @@ public class AugmentScript : MonoBehaviour
     {
         if(augmentScrObj == null) return;
 
-        string divider = "";;
+        string divider = "";
         float stat;
         string statType = "";// = BuffedStatName;
         //Separates Stat names if a space is needed
@@ -167,9 +175,20 @@ public class AugmentScript : MonoBehaviour
             {
                 string buffedDesc = "?" + divider;
                 Description = baseDescription.Replace('#'.ToString(), buffedDesc);
+                if(isConditional)
+                {
+                    // Description = Description.Replace('$', '?');
+                    Description = baseDescription.Replace('$', '?');
+                }
             }else{
                 string buffedDesc = stat.ToString() + divider;
                 Description = baseDescription.Replace('#'.ToString(), buffedDesc);
+                if(isConditional)
+                {
+                    float procDesc = procChance*100f;
+                    // Description = Description.Replace('$', procStr);
+                    Description = baseDescription.Replace('$'.ToString(), procDesc.ToString("N0"));
+                }
             }
             // string conditionalDesc = conditionalBuffedAmount.ToString();
             // Description = baseDescription.Replace('@'.ToString(), conditionalDesc);

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -177,8 +177,11 @@ public class AugmentScript : MonoBehaviour
                 Description = baseDescription.Replace('#'.ToString(), buffedDesc);
                 if(isConditional)
                 {
+                    string tempDesc = Description;
+                    Description = tempDesc.Replace('$'.ToString(), '?'.ToString());
+
                     // Description = Description.Replace('$', '?');
-                    Description = baseDescription.Replace('$', '?');
+                    Description = baseDescription.Replace('$'.ToString(), '?'.ToString());
                 }
             }else{
                 string buffedDesc = stat.ToString() + divider;
@@ -187,7 +190,7 @@ public class AugmentScript : MonoBehaviour
                 {
                     float procDesc = procChance*100f;
                     // Description = Description.Replace('$', procStr);
-                    Description = baseDescription.Replace('$'.ToString(), procDesc.ToString("N0"));
+                    Description = baseDescription.Replace('$'.ToString(), procDesc.ToString("N0")); 
                 }
             }
             // string conditionalDesc = conditionalBuffedAmount.ToString();

--- a/_Augments/Conditional/Base_ConditionalAugments.cs
+++ b/_Augments/Conditional/Base_ConditionalAugments.cs
@@ -22,6 +22,7 @@ public class Base_ConditionalAugments : MonoBehaviour
         timerDuration = 0;
         active = false;
         if(augmentScript == null) augmentScript = GetComponent<AugmentScript>();
+        if(augmentScript != null) procChance = augmentScript.procChance;
     }
 
     public virtual void TriggerAugment()

--- a/_Augments/Conditional/Base_ConditionalAugments.cs
+++ b/_Augments/Conditional/Base_ConditionalAugments.cs
@@ -11,10 +11,15 @@ public class Base_ConditionalAugments : MonoBehaviour
     [SerializeField] public float buffAmount; //TODO: need to update this to the AugmentScript values
     [SerializeField] public float buffAmountPercent;
     [SerializeField] protected Base_PlayerCombat playerCombat;
+
+    [Header("Proc Cooldown")]
+    [SerializeField] protected float procCooldown = 0;
+
     [Header("Debugging")]
     [SerializeField] protected float timerDuration;
     [SerializeField] protected AugmentScript augmentScript;
     [SerializeField] protected int currentLevel;
+    [SerializeField] private float procCooldownTimer;
 
     protected virtual void Start()
     {
@@ -23,6 +28,23 @@ public class Base_ConditionalAugments : MonoBehaviour
         active = false;
         if(augmentScript == null) augmentScript = GetComponent<AugmentScript>();
         if(augmentScript != null) procChance = augmentScript.procChance;
+
+        procCooldownTimer = 0;
+    }
+
+    protected virtual void Update()
+    {
+        if(procCooldownTimer > 0) procCooldownTimer -= Time.deltaTime;
+    }
+
+    public bool CanActivate()
+    {
+        return procCooldownTimer <= 0;
+    }
+
+    public void StartProcCooldown()
+    {
+        procCooldownTimer = procCooldown;
     }
 
     public virtual void TriggerAugment()
@@ -34,6 +56,8 @@ public class Base_ConditionalAugments : MonoBehaviour
     protected virtual void Activate()
     {
         Debug.Log(name + " Augment Activated");
+        if(!CanActivate()) return;
+        StartProcCooldown();
 
         GameManager.Instance.AugmentInventory.augmentInventoryDisplay.ToggleAugmentStatus(augmentScript.displayedIndex, buffDuration);
     }

--- a/_Augments/Conditional/Base_ConditionalAugments.cs
+++ b/_Augments/Conditional/Base_ConditionalAugments.cs
@@ -6,20 +6,20 @@ public class Base_ConditionalAugments : MonoBehaviour
 {
     [Header("Setup")]
     [SerializeField] public float procChance = 1.0f; //default 100%, 0.0 - 1.0f
-    [SerializeField] public float duration;
+    [SerializeField] public float buffDuration;
     [SerializeField] protected bool active;
     [SerializeField] public float buffAmount; //TODO: need to update this to the AugmentScript values
     [SerializeField] public float buffAmountPercent;
     [SerializeField] protected Base_PlayerCombat playerCombat;
     [Header("Debugging")]
-    [SerializeField] protected float durationTimer;
+    [SerializeField] protected float timerDuration;
     [SerializeField] protected AugmentScript augmentScript;
     [SerializeField] protected int currentLevel;
 
     protected virtual void Start()
     {
         playerCombat = GameManager.Instance.PlayerCombat;
-        durationTimer = 0;
+        timerDuration = 0;
         active = false;
         if(augmentScript == null) augmentScript = GetComponent<AugmentScript>();
     }
@@ -33,6 +33,8 @@ public class Base_ConditionalAugments : MonoBehaviour
     protected virtual void Activate()
     {
         Debug.Log(name + " Augment Activated");
+
+        GameManager.Instance.AugmentInventory.augmentInventoryDisplay.ToggleAugmentStatus(augmentScript.displayedIndex, buffDuration);
     }
 
 //

--- a/_Augments/Conditional/CA_AreaOfEffect_Global.cs
+++ b/_Augments/Conditional/CA_AreaOfEffect_Global.cs
@@ -15,6 +15,9 @@ public class CA_AreaOfEffect_Global : Base_ConditionalAugments
 
     protected override void Activate(Transform objectHitPos)
     {
+        if(!CanActivate()) return;
+
+        StartProcCooldown();
         //Instantiate an explosion at the enemy position, prefab applies status effect
         if(explosionPrefab != null)
         {

--- a/_Augments/Conditional/CA_AreaOfEffect_Global.cs
+++ b/_Augments/Conditional/CA_AreaOfEffect_Global.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
 
 public class CA_AreaOfEffect_Global : Base_ConditionalAugments

--- a/_Augments/Conditional/CA_AreaOfEffect_Local.cs
+++ b/_Augments/Conditional/CA_AreaOfEffect_Local.cs
@@ -32,11 +32,10 @@ public class CA_AreaOfEffect_Local : Base_ConditionalAugments
             IDamageable damageable = enemy.GetComponent<IDamageable>();
             if(damageable != null)
             {
-                damageable.TakeDamage(damage, true, knockbackStrength);
+                damageable.TakeDamage(damage, true, false, knockbackStrength);
                 ScreenShakeListener.Instance.Shake(1); //TODO: if Crit
             }
         }
-    
     }
 
     private void OnDrawGizmos()

--- a/_Augments/Conditional/CA_IncreasedAttackSpeed.cs
+++ b/_Augments/Conditional/CA_IncreasedAttackSpeed.cs
@@ -19,9 +19,9 @@ public class CA_IncreasedAttackSpeed : Base_ConditionalAugments
     void FixedUpdate()
     {
         if(!active) return;
-        if(durationTimer <= 0) StopBuff();
+        if(timerDuration <= 0) StopBuff();
         Debug.Log("ATTACK SPEED IS WORKING: " + playerCombat.attackSpeed);
-        durationTimer -= Time.fixedDeltaTime;
+        timerDuration -= Time.fixedDeltaTime;
         // Time.deltaTime
     }
 
@@ -35,7 +35,7 @@ public class CA_IncreasedAttackSpeed : Base_ConditionalAugments
         base.Activate(); //sets values
         if(active)
         {
-            durationTimer = duration; //Refresh duration
+            timerDuration = buffDuration; //Refresh duration
             return;
         }
         
@@ -45,7 +45,7 @@ public class CA_IncreasedAttackSpeed : Base_ConditionalAugments
         
         buffedAttackSpeed = baseAttackSpeed - (baseAttackSpeed * buffAmountPercent); //percent is calculated in AugmentScript
         
-        durationTimer = duration;
+        timerDuration = buffDuration;
         playerCombat.attackSpeed = buffedAttackSpeed; //TODO: need to adjust amount, probably increase Tier to Epic or Legendary
         
 

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -278,7 +278,6 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         //Player behind enemy
         if (enemyController.raycast.playerDetectBack)
         {
-            Debug.Log("Should Flip to get player");
             movement.ManualFlip(!movement.isFacingRight);
         }
     }

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -442,12 +442,13 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         animator.StopAttackAnimCO();
     }
 
-    public virtual void TakeDamage(float damageTaken, bool knockback = false, float strength = 8, float xPos = 0)
+    public virtual void TakeDamage(float damageTaken, bool knockback = false, bool procOnHit = false, float strength = 8, float xPos = 0)
     {
         if (!isAlive || isSpawning) return;
         if (damageImmune) return;
 
         HitFlash(); //Set material to white, short delay before resetting
+        if(procOnHit) GameManager.Instance.AugmentInventory.OnHit(hitEffectsOffset);
 
         float totalDamage = damageTaken - defense;
 
@@ -476,9 +477,32 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         }
     }
 
-    public virtual void TakeDamageStatus(float damageTaken)
+    public virtual void TakeDamageStatus(float damageTaken, int colorIdx)
     {
-        TakeDamage(damageTaken, false);
+        // TakeDamage(damageTaken, false, false);
+
+        if (!isAlive || isSpawning) return;
+        if (damageImmune) return;
+
+        HitFlash(); //Set material to white, short delay before resetting
+
+        float totalDamage = damageTaken - defense;
+
+        //Damage can never be lower than 1
+        if (totalDamage <= 0) totalDamage = 1;
+        InstantiateManager.Instance.HitEffects.ShowHitEffect(hitEffectsOffset.position);
+        currentHP -= totalDamage;
+        healthBar.UpdateHealth(currentHP);
+        if(playAudioClips != null) playAudioClips.PlayRandomClip();
+
+        //Display Damage number
+        InstantiateManager.Instance.TextPopups.ShowStatusDamage(totalDamage, textPopupOffset.position, colorIdx);
+
+        if (currentHP <= 0)
+        {
+            isAlive = false;
+            Die();
+        }
     }
 
     public virtual Transform GetHitPosition()

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -67,12 +67,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
 
     void FixedUpdate()
     {
-        if(!canFly)
-        {
-            movement.rb.gravityScale = originalScale;
-            movement.rb.drag = originalDrag;
-            return;
-        }
+        if(!canFly) return;
         
         //
         var step = movement.moveSpeed * Time.deltaTime;
@@ -576,17 +571,63 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
         {
             //Change to next Phase
             if(changingPhase) return;
+
             currentPhase++;
-            //If flying, drop to ground
-            if(canFly)
-            {
-                canFly = false;
-                movement.rb.gravityScale = originalScale; //TODO: might not be needed if using update check
-                movement.rb.drag = originalDrag;
-            }
             StartCoroutine(ChangePhase());
         }
         attackEndDelay = 0.1f; //If no delay, attackSpeed delay still applies
+    }
+
+    protected override IEnumerator ChangePhase()
+    {
+        // return base.ChangePhase();
+        // protected virtual IEnumerator ChangePhase()
+    
+        changingPhase = true;
+        //Stop Attack and AttackEnd Coroutines
+        StopAttack();        
+
+        //Toggle Shield gameobject and increase defenses
+        PhaseShieldBreak.PlayAnim(0);
+        yield return new WaitForSeconds(PhaseShieldBreak.GetAnimTime(0)); //anim delay before enabling shield
+
+        PhaseShield.SetActive(true);
+        float baseDefense = defense;
+        defense = 999;
+        movement.canMove = false;
+        canAttack = false;
+        
+        yield return new WaitForSeconds(1.5f);
+        animator.PlayManualAnim(6, 1.083f); //Buff anim
+        yield return new WaitForSeconds(0.667f); //Shorter time to pop shield
+
+        //Toggle Shield gameobject and remove defenses
+        PhaseShieldBreak.PlayAnim(1);
+        PhaseShield.SetActive(false);
+        defense = baseDefense;
+        ScreenShakeListener.Instance.Shake(3);
+        yield return new WaitForSeconds(PhaseShieldBreak.GetAnimTime(1));
+        movement.canMove = true;
+        isAttacking = false;
+        canAttack = true;
+        changingPhase = false;
+    
+    }
+
+    protected override void StopAttack(bool toggleFlip = false)
+    {
+        if (AttackingCO != null) StopCoroutine(AttackingCO);
+        if (AttackEndCO != null) StopCoroutine(AttackEndCO);
+        isAttacking = false;
+
+        canFly = false;
+        movement.rb.gravityScale = originalScale;
+        movement.rb.drag = originalDrag;
+
+        movement.canMove = true;
+        movement.ToggleFlip(toggleFlip);
+        //Cancels Attack animation
+        animator.StopAttackAnimCO();
     }
 
     protected override void Die()

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -581,7 +581,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
             if(canFly)
             {
                 canFly = false;
-                movement.rb.gravityScale = originalScale;
+                movement.rb.gravityScale = originalScale; //TODO: might not be needed if using update check
                 movement.rb.drag = originalDrag;
             }
             StartCoroutine(ChangePhase());

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -67,7 +67,12 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
 
     void FixedUpdate()
     {
-        if(!canFly) return;
+        if(!canFly)
+        {
+            movement.rb.gravityScale = originalScale;
+            movement.rb.drag = originalDrag;
+            return;
+        }
         
         //
         var step = movement.moveSpeed * Time.deltaTime;
@@ -578,7 +583,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
                 canFly = false;
                 movement.rb.gravityScale = originalScale;
                 movement.rb.drag = originalDrag;
-            } 
+            }
             StartCoroutine(ChangePhase());
         }
         attackEndDelay = 0.1f; //If no delay, attackSpeed delay still applies

--- a/_Enemy Scripts/Enemy Behaviors/Ranged_Global.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Ranged_Global.cs
@@ -35,10 +35,11 @@ public class Ranged_Global : Ranged_Horizontal
 
 
         combat.PlayIndicator(); //---------------------------
-        Vector3 playerPos = GetPlayerPosX(); //Only get player position here
         
         yield return new WaitForSeconds(chargeUpAnimDelay); //Charge up portion of animation
 
+        Vector3 playerPos = GetPlayerPosX(); //Only get player position here
+        
         combat.animator.PlayManualAnim(0, fullAnimTime);
 
         PlayIndicatorExplode();

--- a/_Enemy Scripts/ProjectileController.cs
+++ b/_Enemy Scripts/ProjectileController.cs
@@ -61,7 +61,7 @@ public class ProjectileController : MonoBehaviour
             var target = collision.GetComponent<Base_EnemyCombat>();
             if(target != null)
             {
-                target.TakeDamageStatus(damage);
+                target.TakeDamageStatus(damage, 3);
                 DestroyProjectile();
                 target.GetKnockback(!playerToRight, knockbackStrength);
             }

--- a/_Enemy Scripts/ProjectileController_Static.cs
+++ b/_Enemy Scripts/ProjectileController_Static.cs
@@ -59,7 +59,7 @@ public class ProjectileController_Static : ProjectileController
             if (player.GetComponent<Base_PlayerCombat>() != null)
             {
                 var playerObj = player.GetComponent<Base_PlayerCombat>();
-                playerObj.TakeDamage(damage);
+                playerObj.TakeDamage(damage, transform.position.x);
                 if (knockbackStrength > 0) playerObj.GetKnockback(transform.position.x, knockbackStrength);
             }
         }

--- a/_Enemy Scripts/Tier 2 Enemies/Shielder_EnemyCombat.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Shielder_EnemyCombat.cs
@@ -49,7 +49,7 @@ public class Shielder_EnemyCombat : Base_EnemyCombat
         Gizmos.DrawWireSphere(attackPoint.position, attackRange);
     }
 
-    public override void TakeDamage(float damageTaken, bool knockback = false, float strength = 8, float xPos = 0)
+    public override void TakeDamage(float damageTaken, bool knockback = false, bool procOnHit = false, float strength = 8, float xPos = 0)
     {
         if (!isAlive || isSpawning) return;
         // if (movement.isFacingRight == playerToRight) //facing player, Shield blocks damage and knockback
@@ -61,13 +61,13 @@ public class Shielder_EnemyCombat : Base_EnemyCombat
             // base.TakeDamage(0, knockback, 0); //TODO: if blocked damage is 0, may just reduce flip during attackCO
             CheckCounterHit();
         }
-        else base.TakeDamage(damageTaken, knockback, strength, xPos);
+        else base.TakeDamage(damageTaken, knockback, procOnHit, strength, xPos);
     }
 
-    public override void TakeDamageStatus(float damageTaken)
+    public override void TakeDamageStatus(float damageTaken, int colorIdx)
     {
         //Ignore Block
-        base.TakeDamage(damageTaken);
+        base.TakeDamageStatus(damageTaken, colorIdx);
     }
 
     protected override void Die()

--- a/_Interfaces/InterfaceDefinitions.cs
+++ b/_Interfaces/InterfaceDefinitions.cs
@@ -6,8 +6,8 @@ public interface IDamageable
 {
     Transform GetHitPosition();
     Transform GetGroundPosition();
-    void TakeDamage(float damageTaken, bool knockback = false, float strength = 8, float xPos = 0);
-    void TakeDamageStatus(float damageTaken);
+    void TakeDamage(float damageTaken, bool knockback = false, bool procOnHit = false, float strength = 8, float xPos = 0);
+    void TakeDamageStatus(float damageTaken, int colorIdx);
 }
 
 public interface IInteractable

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -285,9 +285,9 @@ public class Base_PlayerCombat : MonoBehaviour
             IDamageable damageable = enemy.GetComponent<IDamageable>();
             if(damageable != null)
             {
-                damageable.TakeDamage(damageDealt, true, knockbackStrength, transform.position.x);
-                Transform enemyPos = damageable.GetHitPosition();
-                augmentInventory.OnHit(enemyPos);
+                damageable.TakeDamage(damageDealt, true, true, knockbackStrength, transform.position.x);
+                // Transform enemyPos = damageable.GetHitPosition();
+                // augmentInventory.OnHit(enemyPos); //Calling from Enemy TakeDamage
                 HitStopAnim(attackAnimFull, groundAttack);
 
                 if(isAirAttacking) movement.Float(.3f);
@@ -312,7 +312,7 @@ public class Base_PlayerCombat : MonoBehaviour
             if(damageable != null)
             {
                 // damageable.TakeDamage(1, true, knockbackStrength, transform.position.x);
-                damageable.TakeDamageStatus(1);
+                damageable.TakeDamageStatus(1, 3);
                 Transform enemyPos = damageable.GetHitPosition();
                 augmentInventory.OnParry(enemyPos);
                 // InstantiateManager.Instance.ParryEffects.ShowHitEffect(parryPoint.position, transform.localScale.x);

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -312,7 +312,7 @@ public class Base_PlayerCombat : MonoBehaviour
             if(damageable != null)
             {
                 // damageable.TakeDamage(1, true, knockbackStrength, transform.position.x);
-                damageable.TakeDamageStatus(1, 3);
+                damageable.TakeDamageStatus(1, 0);
                 Transform enemyPos = damageable.GetHitPosition();
                 augmentInventory.OnParry(enemyPos);
                 // InstantiateManager.Instance.ParryEffects.ShowHitEffect(parryPoint.position, transform.localScale.x);

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -565,6 +565,15 @@ public class Base_PlayerCombat : MonoBehaviour
         CheckDie();
     }
 
+    public void TakeTrueDamage(float damageTaken)
+    {
+        if(!isAlive) return;
+
+        currentHP -= damageTaken;
+        healthBar.UpdateHealth(currentHP);
+        CheckDie();
+    }
+
     public void HealPlayer(float healAmount, bool showNumber = true)
     {
         if (!isAlive) return;

--- a/_Status Effects/Base_AoE_Explosion.cs
+++ b/_Status Effects/Base_AoE_Explosion.cs
@@ -50,7 +50,7 @@ public class Base_AoE_Explosion : MonoBehaviour
             IDamageable damageable = enemy.GetComponent<IDamageable>();
             if(damageable != null)
             {
-                damageable.TakeDamage(damage, true, knockbackStrength);
+                damageable.TakeDamage(damage, true, false, knockbackStrength);
                 ScreenShakeListener.Instance.Shake(2);
                 // Transform enemyHitOffset = damageable.GetPosition();
                 Transform enemyHitOffset = damageable.GetGroundPosition();

--- a/_Status Effects/Base_AoE_Explosion.cs
+++ b/_Status Effects/Base_AoE_Explosion.cs
@@ -25,7 +25,7 @@ public class Base_AoE_Explosion : MonoBehaviour
     protected virtual void Start()
     {
         if(animator == null) animator = GetComponent<Animator>();
-        animator.Play(hashedAnimName);
+        if(animDuration > 0) animator.Play(hashedAnimName);
         Explode();
         Invoke("DeleteObject", animDuration); //delete object after the animation is over
     }

--- a/_Status Effects/Base_AoE_Explosion.cs
+++ b/_Status Effects/Base_AoE_Explosion.cs
@@ -12,7 +12,7 @@ public class Base_AoE_Explosion : MonoBehaviour
     [SerializeField] protected float animDuration;
 
     [Header("-----")]
-    [SerializeField] private LayerMask enemyLayer;
+    [SerializeField] protected LayerMask enemyLayer;
     [SerializeField] public float damage;
     [SerializeField] protected float hitboxWidth;
     [SerializeField] protected float hitBoxHeight;
@@ -20,7 +20,10 @@ public class Base_AoE_Explosion : MonoBehaviour
     [SerializeField] protected bool showGizmos = false;
 
     [Header("= Status Effect =")]
-    [SerializeField] GameObject statusEffectPrefab;
+    [SerializeField] protected GameObject statusEffectPrefab;
+
+    [Header("- optional -")]
+    [SerializeField] protected bool attachStatusToEnemy = true;
 
     protected virtual void Start()
     {
@@ -54,7 +57,14 @@ public class Base_AoE_Explosion : MonoBehaviour
 
                 if(statusEffectPrefab != null)
                 {
-                    Instantiate(statusEffectPrefab, enemyHitOffset.position, statusEffectPrefab.transform.rotation, enemy.transform);
+                    if(attachStatusToEnemy)
+                    {
+                        Instantiate(statusEffectPrefab, enemyHitOffset.position, statusEffectPrefab.transform.rotation, enemy.transform);
+                    }
+                    else
+                    {
+                        Instantiate(statusEffectPrefab, enemyHitOffset.position, enemyHitOffset.transform.rotation);
+                    }
                 }
             }
         }

--- a/_Status Effects/Base_DamageOverTime.cs
+++ b/_Status Effects/Base_DamageOverTime.cs
@@ -8,6 +8,7 @@ public class Base_DamageOverTime : MonoBehaviour
     [SerializeField] public float tickFrequency;
     [SerializeField] public float damagePerTick;
     [SerializeField] float duration;
+    [SerializeField] protected int damageColorIdx = 0;
 
     [Header("Status - Debugging -")]
     public bool isActive;
@@ -73,7 +74,7 @@ public class Base_DamageOverTime : MonoBehaviour
 
     void DealDamage()
     {
-        if(enemyCombat != null) enemyCombat.TakeDamageStatus(damagePerTick);
+        if(enemyCombat != null) enemyCombat.TakeDamageStatus(damagePerTick, damageColorIdx);
         if(playerCombat != null) playerCombat.TakeDamage(damagePerTick);
         if(enemyCombat == null && playerCombat == null) isActive = false;
     }

--- a/_Status Effects/Base_DamageOverTime.cs
+++ b/_Status Effects/Base_DamageOverTime.cs
@@ -7,62 +7,91 @@ public class Base_DamageOverTime : MonoBehaviour
     [Header("Setup")]
     [SerializeField] public float tickFrequency;
     [SerializeField] public float damagePerTick;
-    [SerializeField] float duration;
+    [SerializeField] public float duration;
     [SerializeField] protected int damageColorIdx = 0;
 
     [Header("Status - Debugging -")]
     public bool isActive;
-    [SerializeField] float overallTimer;
-    private float tickTimer;
+    [SerializeField] public float overallTimer;
+    protected float tickTimer;
 
     [Header("Target Object")]
     [SerializeField] protected IDamageable enemyCombat;
-    [SerializeField] Base_PlayerCombat playerCombat;
+    [SerializeField] protected Base_PlayerCombat playerCombat;
 
 
     [Header("Animation Setup")]
-    [SerializeField] private Animator anim;
-    [SerializeField] private string animName;
-    [SerializeField] private int hashedAnimName;
-    [SerializeField] private int hashedAnimNameBlank; //-34935967
+    [SerializeField] protected Animator anim;
+    [SerializeField] protected string animName;
+    [SerializeField] protected int hashedAnimName;
+    [SerializeField] protected int hashedAnimNameBlank; //-34935967
 
-    private bool endingStatus = false;
+    protected bool endingStatus = false;
 
-    void Awake()
+    protected void Awake()
     {
         if(anim == null) anim = GetComponent<Animator>();
     }
     
-    void Start()
+    protected virtual void Start()
     {
         isActive = true;
         if(hashedAnimName != 0) anim.Play(hashedAnimName);
         else anim.Play(animName);
         tickTimer = 0;
-        overallTimer = 0;
+        overallTimer = duration;
         endingStatus = false;
 
         enemyCombat = GetComponentInParent<IDamageable>();
         playerCombat = GetComponentInParent<Base_PlayerCombat>();
+
     }
 
-    void FixedUpdate()
+    protected virtual void CheckForExistingDoT()
+    {
+        //Not called by default, override with inherit
+        Base_DamageOverTime existingDoT = transform.parent.GetComponentInChildren<Base_DamageOverTime>();
+        if(existingDoT != null)
+        {
+            overallTimer += duration;
+            damagePerTick += 1;
+        }
+    }
+
+    public virtual void AddToBaseDuration(float durationAdded)
+    {
+        duration += durationAdded;
+    }
+
+    public virtual void ExtendTimer(float timeAdded)
+    {
+        overallTimer += timeAdded;
+        //Timer cannot exceed full duration by default
+        if(overallTimer > duration) overallTimer = duration;
+    }
+
+    public virtual void ResetTimer()
+    {
+        overallTimer = duration;
+    }
+
+    protected virtual void FixedUpdate()
     {
         if(isActive)
         {
-            overallTimer += Time.deltaTime;
-            if(overallTimer >= duration + 1) //+1 to allow for 1s delay
+            overallTimer -= Time.deltaTime;
+            if(overallTimer <= 0) //+1 to allow for 1s delay
             {
                 isActive = false;
                 return;
             }
 
-            tickTimer += Time.deltaTime;
+            tickTimer -= Time.deltaTime; //Countdown timer
 
-            if(tickTimer >= tickFrequency) //1 second
+            if(tickTimer <= 0) //
             {
                 DealDamage();
-                tickTimer = 0;
+                tickTimer = tickFrequency; //Reset tick timer
             }
         }
         else
@@ -72,14 +101,14 @@ public class Base_DamageOverTime : MonoBehaviour
         }
     }
 
-    void DealDamage()
+    protected void DealDamage()
     {
         if(enemyCombat != null) enemyCombat.TakeDamageStatus(damagePerTick, damageColorIdx);
         if(playerCombat != null) playerCombat.TakeDamage(damagePerTick);
         if(enemyCombat == null && playerCombat == null) isActive = false;
     }
 
-    IEnumerator EndStatus(float endDelay = 1)
+    protected IEnumerator EndStatus(float endDelay = 1)
     {
         endingStatus = true;
         anim.Play(hashedAnimNameBlank);

--- a/_Status Effects/Base_Spawn_AoE.cs
+++ b/_Status Effects/Base_Spawn_AoE.cs
@@ -7,6 +7,7 @@ public class Base_Spawn_AoE : MonoBehaviour
     [Header("Setup")]
     [SerializeField] public float damage = 5;
     [SerializeField] public float knockbackStrength = 1;
+    [SerializeField] public bool canProcOnHit = true;
 
     [Header("HitBox")]
     [SerializeField] protected LayerMask enemyLayer;
@@ -34,7 +35,7 @@ public class Base_Spawn_AoE : MonoBehaviour
     protected virtual IEnumerator Attack()
     {
         anim.Play(hashedAnimName);
-        
+
         yield return new WaitForSeconds(animDelayTime);
         CheckHit();
 
@@ -56,7 +57,7 @@ public class Base_Spawn_AoE : MonoBehaviour
             IDamageable damageable = enemy.GetComponent<IDamageable>();
             if(damageable != null)
             {
-                damageable.TakeDamage(damage, true, knockbackStrength);
+                damageable.TakeDamage(damage, true, canProcOnHit, knockbackStrength);
                 ScreenShakeListener.Instance.Shake(1); //TODO: if Crit
             }
         }

--- a/_Status Effects/Base_Spawn_AoE.cs
+++ b/_Status Effects/Base_Spawn_AoE.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Base_Spawn_AoE : MonoBehaviour
+{
+    [Header("Setup")]
+    [SerializeField] public float damage = 5;
+    [SerializeField] public float knockbackStrength = 1;
+
+    [Header("HitBox")]
+    [SerializeField] protected LayerMask enemyLayer;
+    [SerializeField] protected float hitboxWidth = .5f;
+    [SerializeField] protected float hitBoxHeight = .5f;
+    [SerializeField] private bool showGizmos = false;
+    [SerializeField] protected Transform hitboxOffset;
+    
+    [Header("Animation Setup")]
+    [SerializeField] protected Animator anim;
+    [SerializeField] protected string animName;
+    [SerializeField] protected int hashedAnimName;
+    [SerializeField] protected int hashedAnimNameBlank; //-34935967
+
+    [Space(10)]
+    [SerializeField] protected float fullAnimTime;
+    [SerializeField] protected float animDelayTime;
+
+    
+    protected void OnEnable() //TODO: or Start(), OnEnable() if pooling
+    {
+        StartCoroutine(Attack());
+    }
+
+    protected virtual IEnumerator Attack()
+    {
+        anim.Play(hashedAnimName);
+        
+        yield return new WaitForSeconds(animDelayTime);
+        CheckHit();
+
+        yield return new WaitForSeconds(fullAnimTime - animDelayTime);
+        Destroy(gameObject);
+    }
+
+    protected virtual void CheckHit()
+    {
+        //Only affects enemies within hitbox range
+        Collider2D[] hitEnemies = 
+            Physics2D.OverlapBoxAll(hitboxOffset.position,
+            new Vector2(hitboxWidth, hitBoxHeight), 0, enemyLayer);
+
+        //if (damageMultiplier > 1) knockbackStrength = 6; //TODO: set variable defintion in Inspector
+
+        foreach (Collider2D enemy in hitEnemies)
+        {
+            IDamageable damageable = enemy.GetComponent<IDamageable>();
+            if(damageable != null)
+            {
+                damageable.TakeDamage(damage, true, knockbackStrength);
+                ScreenShakeListener.Instance.Shake(1); //TODO: if Crit
+            }
+        }
+    }
+
+    private void OnDrawGizmos()
+    {
+        if (showGizmos)
+        {
+            if (hitboxOffset == null) return;
+
+            Gizmos.DrawWireCube(hitboxOffset.position, 
+                new Vector3((hitboxWidth),
+                hitBoxHeight, 0));
+        }
+    }
+}

--- a/_Status Effects/Base_Spawn_AoE.cs.meta
+++ b/_Status Effects/Base_Spawn_AoE.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 108e84f58f79a6f47a653fb4eeb67bef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Status Effects/Bleed_DamageOverTime.cs
+++ b/_Status Effects/Bleed_DamageOverTime.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Bleed_DamageOverTime : Base_DamageOverTime
+{
+    [Header("- Bleed -")]
+    // [SerializeField] private float extendTimer = 2;
+    [SerializeField] private float damageIncreasePerTick = 1;
+    [SerializeField] private float maxDamagePerTick = 20;
+    [SerializeField] List<Bleed_DamageOverTime> existingBleeds;
+
+    protected override void Start()
+    {
+        existingBleeds = new List<Bleed_DamageOverTime>();
+
+        base.Start();
+        CheckForExistingDoT();
+    }
+
+    protected override void CheckForExistingDoT()
+    {
+        int totalBleeds = 0;
+
+        for(int i=0; i<transform.parent.childCount; i++)
+        {
+            Bleed_DamageOverTime currBleed = transform.parent.GetChild(i).GetComponent<Bleed_DamageOverTime>();
+
+            //Only longer duration if target is already poisoned
+            if(currBleed != null)
+            {
+                existingBleeds.Add(currBleed);
+                totalBleeds++;
+            }
+            if(totalBleeds > 1)
+            {
+                existingBleeds[0].ResetTimer(); //Reset local duration
+                existingBleeds[0].IncreaseDamagePerTick(damageIncreasePerTick);
+                isActive = false;
+            }
+        }
+    }
+
+    public void IncreaseDamagePerTick(float addDamagePerTick)
+    {
+        damagePerTick += addDamagePerTick;
+        //Damage cannot exceed max
+        if(damagePerTick > maxDamagePerTick)
+            damagePerTick = maxDamagePerTick;
+    }
+}

--- a/_Status Effects/Bleed_DamageOverTime.cs.meta
+++ b/_Status Effects/Bleed_DamageOverTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 622b8a963462067449a65fe6be2287cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Status Effects/Extend_DamageOverTime.cs
+++ b/_Status Effects/Extend_DamageOverTime.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Extend_DamageOverTime : Base_DamageOverTime
+{
+    [Header("- Extend -")]
+    [SerializeField] private float extendDuration = .33f; //Increases full duration
+    [SerializeField] private float extendTimer = .5f; //Extends timer
+    // [SerializeField] List<Base_DamageOverTime> currentDoTs;
+    
+    protected override void Start()
+    {
+        // currentDoTs = new List<Base_DamageOverTime>();
+
+        base.Start();
+        CheckForExistingDoT();
+    }
+
+    protected override void CheckForExistingDoT()
+    {
+        for(int i=0; i<transform.parent.childCount; i++)
+        {
+            Base_DamageOverTime existingDoT = transform.parent.GetChild(i).GetComponent<Base_DamageOverTime>();
+
+            if(existingDoT != null)
+            {
+                //Extend base duration of current status
+                existingDoT.AddToBaseDuration(extendDuration);
+                existingDoT.ExtendTimer(extendTimer);
+            }
+        }
+
+    }
+}

--- a/_Status Effects/Extend_DamageOverTime.cs.meta
+++ b/_Status Effects/Extend_DamageOverTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47b258bf1f4ae8a42aec0ef077a96b63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Status Effects/Poison_DamageOverTime.cs
+++ b/_Status Effects/Poison_DamageOverTime.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Poison_DamageOverTime : Base_DamageOverTime
+{
+    [Header("- Poison -")]
+    [SerializeField] private float extendTimer = 2;
+    [SerializeField] List<Poison_DamageOverTime> existingPoisons;
+
+    protected override void Start()
+    {
+        existingPoisons = new List<Poison_DamageOverTime>();
+
+        base.Start();
+        CheckForExistingDoT();
+    }
+
+    protected override void CheckForExistingDoT()
+    {
+        int totalPoisons = 0;
+
+        for(int i=0; i<transform.parent.childCount; i++)
+        {
+            Poison_DamageOverTime existingPoison = transform.parent.GetChild(i).GetComponent<Poison_DamageOverTime>();
+
+            //Only longer duration if target is already poisoned
+            if(existingPoison != null)
+            {
+                existingPoisons.Add(existingPoison);
+                totalPoisons++;
+            }
+            if(totalPoisons > 1)
+            {
+                existingPoisons[0].overallTimer += extendTimer;
+                isActive = false;
+            }
+        }
+    }
+
+    public override void ExtendTimer(float timeAdded)
+    {
+        overallTimer += timeAdded;
+        //Timer cannot exceed full duration
+        // if(overallTimer > duration) overallTimer = duration; //No limit to duration for Poison
+    }
+
+    protected override void FixedUpdate()
+    {
+        if(isActive)
+        {
+            overallTimer -= Time.deltaTime;
+            if(overallTimer <= 0) //+1 to allow for 1s delay
+            {
+                isActive = false;
+                return;
+            }
+
+            tickTimer -= Time.deltaTime; //Countdown timer
+
+            if(tickTimer <= 0) //
+            {
+                DealDamage();
+                tickTimer = tickFrequency; //Reset tick timer
+            }
+        }
+        else
+        {
+            if(endingStatus) return;
+            StartCoroutine(EndStatus());
+        }
+    }
+}

--- a/_Status Effects/Poison_DamageOverTime.cs.meta
+++ b/_Status Effects/Poison_DamageOverTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22ad22ecbb5040b4abfb387451e51b0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Status Effects/Spawn_AoE_Explosion.cs
+++ b/_Status Effects/Spawn_AoE_Explosion.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Spawn_AoE_Explosion : Base_AoE_Explosion
+{
+    [Header("= Spawn Only =")]
+    [SerializeField] Transform hitboxOffset;
+
+    protected override void Explode()
+    {
+        // base.Explode();
+        Collider2D[] hitEnemies = 
+            Physics2D.OverlapBoxAll(hitboxOffset.position,
+            new Vector2(hitboxWidth, hitBoxHeight), 0, enemyLayer);
+
+        foreach(Collider2D enemy in hitEnemies)
+        {
+            IDamageable damageable = enemy.GetComponent<IDamageable>();
+            if(damageable != null)
+            {
+                // damageable.TakeDamage(damage, true, knockbackStrength);
+                // ScreenShakeListener.Instance.Shake(2);
+                
+                // Transform enemyHitOffset = damageable.GetPosition();
+                Transform enemyHitOffset = damageable.GetGroundPosition();
+
+                if(statusEffectPrefab != null)
+                {
+                    Instantiate(statusEffectPrefab, enemyHitOffset.position, statusEffectPrefab.transform.rotation, enemy.transform);
+                }
+            }
+        }
+    }
+}

--- a/_Status Effects/Spawn_AoE_Explosion.cs.meta
+++ b/_Status Effects/Spawn_AoE_Explosion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf9a638b49bb6b944b1a57e3e38232e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Augments
- Augments with buff durations now display a timer above the Augment icon when Activated
- Added Proc chance to augment descriptions
  - Proc chance in the base description is represented with a '$' char to be replaced in AugmentScript
- Added Cooldown to conditional Augments
- **New Augments**
  - **Caustic** - applies a Poison damage-over-time status to the target
    - Damage cannot stack, but the duration can be extended with additional Poison stacks
  - **Lacerate** - inflicts Bleed status, additional stacks refresh the duration and increase damage
  - **Echo** - chance on-hit to Spawn a Player clone to attack once at the target position
    - Chance to proc on-hit effects, including itself with a cooldown
  - **Extend** - increases base duration and extends timer of existing status effects
    - This can't reset the timer past the full duration, but slightly increases the full duration each proc
---
### Enemies
- Cast Explosions now fire a raycast down to move the explosion to the ground before exploding
  - Added new delayed explosion animation
- Archer can now be parried, narrowed projectile visual and hitbox

### Level Gen
- Added restrictions to which Shops can be generated
- Blood Shop now deals true damage to the Player, ignoring defenses

### Misc
- Player pickups moved to their own collision layer, fixes issues with pickups blocking projectiles
- Added parameter check to TakeDamage() to specify which damage source can proc On-Hit effects
  - Currently only Player and Echo can proc On-Hit
- Fixed issue with Colossal Boss being stuck in flying state if changing phases mid-flight
- Changed colors of status effect damage
  - Burn -> Orange
  - Poison -> Purple
  - Bleed -> Red
  - Defaults to White
- Updated damage numbers to display as whole or float numbers
  - TextPopUpHandler determines which one to display when being passed a number
- Updated Parry timing and duration