### PR TITLE
New Augments, Parry update

### DIFF
--- a/DEBUGGING_MODE.cs
+++ b/DEBUGGING_MODE.cs
@@ -28,6 +28,7 @@ public class DEBUGGING_MODE : MonoBehaviour
             if(playerCombat == null) return;
             playerCombat.maxHP = 9999;
             playerCombat.HealPlayer(9999);
+            playerCombat.kbResist = 9999;
         }
 
         if(Input.GetKey(KeyCode.LeftShift))

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -60,8 +60,8 @@ public class AugmentDisplay : MonoBehaviour
         else ToggleDescriptionDisplay(true);
 
         //Info refresh
-        int level = augmentScript.AugmentLevel;
-        augmentScript.UpdateLevel(level);
+        // int level = augmentScript.AugmentLevel;
+        // augmentScript.UpdateLevel(level);
 
         if(ownedText != null) ownedText.SetActive(false);
         if(timerParent != null) timerParent.SetActive(false);
@@ -228,6 +228,7 @@ public class AugmentDisplay : MonoBehaviour
 
                 if(selectMenu.IsMaxLevel(augmentScript)) //max Level no upgrade
                 {
+                    DisplayLevel.text = "Lv" + augmentScript.AugmentLevel;
                     augmentScript.UpdateDescription();
                     randomizeLevel = false;
 

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -59,6 +59,10 @@ public class AugmentDisplay : MonoBehaviour
         if(!alwaysDisplay) ToggleDescriptionDisplay(false);
         else ToggleDescriptionDisplay(true);
 
+        //Info refresh
+        int level = augmentScript.AugmentLevel;
+        augmentScript.UpdateLevel(level);
+
         if(ownedText != null) ownedText.SetActive(false);
         if(timerParent != null) timerParent.SetActive(false);
 

--- a/_Augments/AugmentInventory.cs
+++ b/_Augments/AugmentInventory.cs
@@ -58,14 +58,14 @@ public class AugmentInventory : MonoBehaviour
     }
 
 #region Conditional Augments
-    public void OnKill(Transform enemyPosition)
+    public void OnKill(Transform enemyPosition, float addProcChance = 0)
     {
         //Currently being called in Base_EnemyCombat
         Debug.Log("OnKill");
         if(onKillAugments.Count <= 0) return;
         for(int i=0; i<onKillAugments.Count; i++)
         {
-            onKillAugments[i].TriggerAugment(enemyPosition);
+            onKillAugments[i].TriggerAugment(enemyPosition, addProcChance);
         }
     }
 
@@ -79,33 +79,35 @@ public class AugmentInventory : MonoBehaviour
         }
     }
 
-    public void OnHit()
+    public void OnHit(float addProcChance = 0)
     {
         Debug.Log("OnHit");
         if(onHitAugments.Count <= 0) return;
         for(int i=0; i<onHitAugments.Count; i++)
         {
-            onHitAugments[i].TriggerAugment();
+            onHitAugments[i].TriggerAugment(addProcChance);
         }
     }
 
-    public void OnHit(Transform objectHitPos)
+    public void OnHit(Transform objectHitPos, float addProcChance = 0)
     {
         Debug.Log("OnHit position");
         if(onHitAugments.Count <= 0) return;
         for(int i=0; i<onHitAugments.Count; i++)
         {
-            onHitAugments[i].TriggerAugment(objectHitPos);
+            onHitAugments[i].TriggerAugment(objectHitPos, addProcChance);
         }
     }
 
-    public void OnParry(Transform objectHitPos)
+    //
+
+    public void OnParry(Transform objectHitPos, float addProcChance = 0)
     {
         Debug.Log("On Parry");
         if(onParryAugments.Count <= 0) return;
         for(int i=0; i<onParryAugments.Count; i++)
         {
-            onParryAugments[i].TriggerAugment(objectHitPos);
+            onParryAugments[i].TriggerAugment(objectHitPos, addProcChance);
         }
     }
 

--- a/_Augments/AugmentInventory.cs
+++ b/_Augments/AugmentInventory.cs
@@ -180,6 +180,8 @@ public class AugmentInventory : MonoBehaviour
         combat.attackSpeed += modified_AttackSpeed; //lower is faster, stats are already subtracted
         combat.knockbackStrength += modified_KnockbackStrength;
         combat.kbResist += modified_kbResist;
+
+        SetConditionalStats();
     }
 
     private void ResetModifiedStats()
@@ -191,6 +193,14 @@ public class AugmentInventory : MonoBehaviour
         modified_AttackSpeed = 0;
         modified_KnockbackStrength = 0;
         modified_kbResist = 0;
+    }
+
+    private void SetConditionalStats()
+    {
+        for(int i=0; i<heldAugments.Count; i++)
+        {
+            heldAugments[i].AddConditionalAugment(); //Only for Unstable augments
+        }
     }
 #endregion
 
@@ -237,6 +247,7 @@ public class AugmentInventory : MonoBehaviour
         heldAugmentDisplays.Add(currDisplay);
 
         if(augmentInventoryDisplay != null) augmentInventoryDisplay.AddAugmentToDisplay(heldAugments);
+        
         UpdateAugments();
     }
 

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -51,7 +51,11 @@ public class AugmentScript : MonoBehaviour
     void Awake()
     {
         // if(Description == null) Description = GetComponentInChildren<TextMeshProUGUI>();
-        if(augmentScrObj == null) return;
+        if(augmentScrObj == null)
+        {
+            Debug.Log(name + " No AugmentScrObj");
+            return;
+        } 
         MaxLevel = augmentScrObj.MaxLevel; //Max level is determined by its tier;
         GetAugmentVariables();
     }
@@ -88,6 +92,7 @@ public class AugmentScript : MonoBehaviour
         procChance = augmentScrObj.procChance;
         // baseBuffedAmountPercent = 
         // DebuffedStat = augmentScrObj. //TODO: might just use "modifiedStat", then use + or - for changes
+        UpdateLevel(AugmentLevel);
         UpdateConditional();
         UpdateDescription();
         Debug.Log("Augment Stats loaded");
@@ -95,18 +100,17 @@ public class AugmentScript : MonoBehaviour
 //
     private void UpdateConditional()
     {
-        if(ConditionalAugmentScript == null) return;
-        // ConditionalAugmentScript.buffAmount = buffedAmount;
-        // ConditionalAugmentScript.buffAmountPercent = buffedAmountPercent;
+        if(ConditionalAugmentScript == null || augmentScrObj == null) return;
 
         //Update proc chance with current level
         procChance = augmentScrObj.procChance + ((AugmentLevel - 1) * augmentScrObj.procChancePerLevel);
-        ConditionalAugmentScript.UpdateLevelStats();
+
+        if(isConditional) ConditionalAugmentScript.UpdateLevelStats();
     }
 
     public void UpdateLevel(int level)
     {
-        if(level >= MaxLevel) AugmentLevel = MaxLevel;
+        if(level > MaxLevel) AugmentLevel = MaxLevel;
         else AugmentLevel = level;
 
         UpdateStatsToLevel();

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
-using UnityEngine.TextCore.Text;
 
 public class AugmentScript : MonoBehaviour
 {
@@ -107,10 +106,19 @@ public class AugmentScript : MonoBehaviour
 
     public void UpdateLevel(int level)
     {
-        AugmentLevel = level;
+        if(level >= MaxLevel) AugmentLevel = MaxLevel;
+        else AugmentLevel = level;
+
         UpdateStatsToLevel();
     }
 
+#region Augment Added to Inventory
+    public void AddConditionalAugment()
+    {
+        if(ConditionalAugmentScript == null) return;
+        ConditionalAugmentScript.SetConditionalAugmentStats();
+    }
+#endregion
 
 #region Change Stats based on Level
     private void UpdateStatsToLevel()

--- a/_Augments/Conditional/Base_ConditionalAugments.cs
+++ b/_Augments/Conditional/Base_ConditionalAugments.cs
@@ -86,5 +86,8 @@ public class Base_ConditionalAugments : MonoBehaviour
         buffAmountPercent = augmentScript.buffedAmountPercent * .01f; //Convert to %
     }
 
-    
+    public virtual void SetConditionalAugmentStats()
+    {
+        //placeholder for override
+    }
 }

--- a/_Augments/Conditional/Base_ConditionalAugments.cs
+++ b/_Augments/Conditional/Base_ConditionalAugments.cs
@@ -47,10 +47,19 @@ public class Base_ConditionalAugments : MonoBehaviour
         procCooldownTimer = procCooldown;
     }
 
-    public virtual void TriggerAugment()
+    public virtual void TriggerAugment(float addProcChance = 0)
     {
         float rand = Random.Range(0f, 1.0f);
-	    if(rand < procChance) Activate();
+	    if(rand < (procChance + addProcChance))
+            Activate();
+    }
+    
+    public virtual void TriggerAugment(Transform objectHitPos, float addProcChance = 0)
+    {
+        float rand = Random.Range(0f, 1.0f);
+	    // if(rand < procChance) Activate(objectHitPos);
+        if(rand < (procChance + addProcChance))
+            Activate(objectHitPos);
     }
 
     protected virtual void Activate()
@@ -60,14 +69,6 @@ public class Base_ConditionalAugments : MonoBehaviour
         StartProcCooldown();
 
         GameManager.Instance.AugmentInventory.augmentInventoryDisplay.ToggleAugmentStatus(augmentScript.displayedIndex, buffDuration);
-    }
-
-//
-
-    public virtual void TriggerAugment(Transform objectHitPos)
-    {
-        float rand = Random.Range(0f, 1.0f);
-	    if(rand < procChance) Activate(objectHitPos);
     }
 
     protected virtual void Activate(Transform objectHitPos)
@@ -84,4 +85,6 @@ public class Base_ConditionalAugments : MonoBehaviour
         buffAmount = augmentScript.buffedAmount;
         buffAmountPercent = augmentScript.buffedAmountPercent * .01f; //Convert to %
     }
+
+    
 }

--- a/_Augments/Conditional/CA_AreaOfEffect_Global.cs
+++ b/_Augments/Conditional/CA_AreaOfEffect_Global.cs
@@ -20,7 +20,7 @@ public class CA_AreaOfEffect_Global : Base_ConditionalAugments
         StartProcCooldown();
         //Instantiate an explosion at the enemy position, prefab applies status effect
         if(explosionPrefab != null)
-        {
+        {    
             Instantiate(explosionPrefab, objectHitPos.position, explosionPrefab.transform.rotation);
         }
         else

--- a/_Augments/Conditional/CA_AreaOfEffect_Global.cs
+++ b/_Augments/Conditional/CA_AreaOfEffect_Global.cs
@@ -8,9 +8,15 @@ public class CA_AreaOfEffect_Global : Base_ConditionalAugments
     //Explosion is instantiated at the Enemy position
     [SerializeField] GameObject explosionPrefab;
 
+    [Header("- optional override -")]
+    [SerializeField] protected bool usePlayerDamage = false;
+    [Header("- Debug - set at Start()")]
+    [SerializeField] Base_AoE_Explosion explosionPrefabScript;
+
     protected override void Start()
     {
         base.Start();
+        explosionPrefabScript = explosionPrefab.GetComponent<Base_AoE_Explosion>();
     }
 
     protected override void Activate(Transform objectHitPos)
@@ -20,8 +26,16 @@ public class CA_AreaOfEffect_Global : Base_ConditionalAugments
         StartProcCooldown();
         //Instantiate an explosion at the enemy position, prefab applies status effect
         if(explosionPrefab != null)
-        {    
-            Instantiate(explosionPrefab, objectHitPos.position, explosionPrefab.transform.rotation);
+        {
+            if(usePlayerDamage)
+            {
+                explosionPrefabScript.damage = playerCombat.GetMultipliedDamage();
+                Instantiate(explosionPrefab, objectHitPos.position, explosionPrefab.transform.rotation);
+            }
+            else
+            {
+                Instantiate(explosionPrefab, objectHitPos.position, explosionPrefab.transform.rotation);
+            }
         }
         else
         {

--- a/_Augments/Conditional/CA_AreaOfEffect_Local.cs
+++ b/_Augments/Conditional/CA_AreaOfEffect_Local.cs
@@ -12,6 +12,10 @@ public class CA_AreaOfEffect_Local : Base_ConditionalAugments
     [SerializeField] private float knockbackStrength = 4f;
     [SerializeField] private bool showGizmos = false;
 
+    [Header("- optional -")]
+    [SerializeField] protected bool hasAnimation = false;
+    [SerializeField] protected int blockIndicatorIdx;
+
     protected override void Start()
     {
         base.Start();
@@ -27,6 +31,8 @@ public class CA_AreaOfEffect_Local : Base_ConditionalAugments
 
         //if (damageMultiplier > 1) knockbackStrength = 6; //TODO: set variable defintion in Inspector
 
+        if(hasAnimation) PlayEffectOnPlayer();
+
         foreach (Collider2D enemy in hitEnemies)
         {
             IDamageable damageable = enemy.GetComponent<IDamageable>();
@@ -35,6 +41,7 @@ public class CA_AreaOfEffect_Local : Base_ConditionalAugments
                 damageable.TakeDamage(damage, true, false, knockbackStrength);
                 ScreenShakeListener.Instance.Shake(1); //TODO: if Crit
             }
+            //
         }
     }
 
@@ -48,5 +55,10 @@ public class CA_AreaOfEffect_Local : Base_ConditionalAugments
                 new Vector3((hitboxWidth),
                 hitBoxHeight, 0));
         }
+    }
+
+    void PlayEffectOnPlayer()
+    {
+        playerCombat.ToggleIndicator(blockIndicatorIdx);
     }
 }

--- a/_Augments/Conditional/CA_IncreasedAttackSpeed.cs
+++ b/_Augments/Conditional/CA_IncreasedAttackSpeed.cs
@@ -20,7 +20,6 @@ public class CA_IncreasedAttackSpeed : Base_ConditionalAugments
     {
         if(!active) return;
         if(timerDuration <= 0) StopBuff();
-        Debug.Log("ATTACK SPEED IS WORKING: " + playerCombat.attackSpeed);
         timerDuration -= Time.fixedDeltaTime;
         // Time.deltaTime
     }

--- a/_Augments/Conditional/CA_IncreasedDamage.cs
+++ b/_Augments/Conditional/CA_IncreasedDamage.cs
@@ -5,13 +5,12 @@ using UnityEngine;
 public class CA_IncreasedDamage : Base_ConditionalAugments
 {
     [Header("= CA_IncreaseAttackSpeed =")]
-    [SerializeField] float baseAttackDamage; //return to this value after effect ends
-    [SerializeField] float buffedAttackDamage; //combat.attackSpeed is set to this value for the duration
+    [SerializeField] float buffedAttackDamage; //combat.attackDamage is set to this value for the duration
     
     protected override void Start()
     {
         base.Start();
-        baseAttackDamage = GameManager.Instance.AugmentInventory.base_AttackDamage;
+        // baseAttackDamage = GameManager.Instance.AugmentInventory.base_AttackDamage;
     }
 
     void FixedUpdate()
@@ -25,24 +24,25 @@ public class CA_IncreasedDamage : Base_ConditionalAugments
     protected override void Activate()
     {
         base.Activate(); //sets values
+
         if(active)
         {
             timerDuration = buffDuration; //Refresh duration
+            StartProcCooldown();
             return;
         }
         
         active = true;
 
-        buffedAttackDamage = baseAttackDamage + buffAmount;
+        buffedAttackDamage = playerCombat.base_attackDamage + buffAmount;
         
         timerDuration = buffDuration;
         playerCombat.attackDamage = buffedAttackDamage;
-        
     }
 
     protected virtual void StopBuff()
     {
         active = false;
-        playerCombat.attackDamage = baseAttackDamage;
+        playerCombat.attackDamage = playerCombat.base_attackDamage;
     }
 }

--- a/_Augments/Conditional/CA_IncreasedDamage.cs
+++ b/_Augments/Conditional/CA_IncreasedDamage.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CA_IncreasedDamage : Base_ConditionalAugments
+{
+    [Header("= CA_IncreaseAttackSpeed =")]
+    [SerializeField] float baseAttackDamage; //return to this value after effect ends
+    [SerializeField] float buffedAttackDamage; //combat.attackSpeed is set to this value for the duration
+    
+    protected override void Start()
+    {
+        base.Start();
+        baseAttackDamage = GameManager.Instance.AugmentInventory.base_AttackDamage;
+    }
+
+    void FixedUpdate()
+    {
+        if(!active) return;
+        if(timerDuration <= 0) StopBuff();
+        timerDuration -= Time.fixedDeltaTime;
+        // Time.deltaTime
+    }
+
+    protected override void Activate()
+    {
+        base.Activate(); //sets values
+        if(active)
+        {
+            timerDuration = buffDuration; //Refresh duration
+            return;
+        }
+        
+        active = true;
+
+        buffedAttackDamage = baseAttackDamage + buffAmount;
+        
+        timerDuration = buffDuration;
+        playerCombat.attackDamage = buffedAttackDamage;
+        
+    }
+
+    protected virtual void StopBuff()
+    {
+        active = false;
+        playerCombat.attackDamage = baseAttackDamage;
+    }
+}

--- a/_Augments/Conditional/CA_IncreasedDamage.cs.meta
+++ b/_Augments/Conditional/CA_IncreasedDamage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf83c1a1fee4a074a876d9be12f358e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/Conditional/CA_OnHit_OnKill.cs
+++ b/_Augments/Conditional/CA_OnHit_OnKill.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CA_OnHit_OnKill : Base_ConditionalAugments
+{
+    [Header("- Proc On-Kill with On-Hit -")]
+    [SerializeField] float onHitAddProcChance = 0; //additional proc chance, default still applies
+    [SerializeField] float newAttackDamage = 1;
+    
+    protected override void Start()
+    {
+        base.Start();
+        onHitAddProcChance = procChance;
+        //Parry has 100% proc, but still rolls normally for OnHit or OnKill augments
+    }
+
+    public override void TriggerAugment(Transform objectHitPos, float addProcChance = 0)
+    {
+        // base.TriggerAugment(objectHitPos, addProcChance);
+        //Guaranteed proc
+        Activate(objectHitPos);
+    }
+
+    protected override void Activate(Transform objectHitPos)
+    {
+        // base.Activate();
+        if(!CanActivate()) return;
+        StartProcCooldown();
+
+        GameManager.Instance.AugmentInventory.OnKill(objectHitPos, onHitAddProcChance);   
+    }
+
+    public override void SetConditionalAugmentStats()
+    {
+        base.SetConditionalAugmentStats();
+        
+        //Only called once the Augment is purchased
+        //Called after updating stats from Augments
+        playerCombat.base_attackDamage = newAttackDamage;
+        playerCombat.attackDamage = newAttackDamage;
+
+        playerCombat.maxHP -= 20;
+        playerCombat.HealPlayer(0); //update current health
+    }
+}

--- a/_Augments/Conditional/CA_OnHit_OnKill.cs.meta
+++ b/_Augments/Conditional/CA_OnHit_OnKill.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a583d9793d56fc42907d3a680e3e9b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/Conditional/CA_Parry_OnHit.cs
+++ b/_Augments/Conditional/CA_Parry_OnHit.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CA_Parry_OnHit : Base_ConditionalAugments
+{
+    [Header("- Parry -")]
+    [SerializeField] float onHitAddProcChance = 0;
+    [SerializeField] bool procOnHit = false;
+    [SerializeField] bool procOnKill = false;
+
+    protected override void Start()
+    {
+        base.Start();
+        onHitAddProcChance = procChance; 
+        //Parry has 100% proc, but still rolls normally for OnHit or OnKill augments
+    }
+
+    public override void TriggerAugment(Transform objectHitPos, float addProcChance = 0)
+    {
+        // base.TriggerAugment(objectHitPos, addProcChance);
+        //Guaranteed proc
+        Activate(objectHitPos);
+    }
+
+    protected override void Activate(Transform objectHitPos)
+    {
+        Debug.Log(name + " Augment activated");
+        // base.Activate();
+        if(!CanActivate()) return;
+        StartProcCooldown();
+
+        if(procOnHit)
+            GameManager.Instance.AugmentInventory.OnHit(objectHitPos, onHitAddProcChance);
+
+        if(procOnKill)
+            GameManager.Instance.AugmentInventory.OnKill(objectHitPos, onHitAddProcChance);
+
+        //TODO: can't get groundPos using getcomponent
+        // Transform groundPos = objectHitPos.GetComponent<IDamageable>().GetGroundPosition();
+        // GameManager.Instance.AugmentInventory.OnKill(groundPos);
+    }
+}

--- a/_Augments/Conditional/CA_Parry_OnHit.cs.meta
+++ b/_Augments/Conditional/CA_Parry_OnHit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f7211b1d40e8ec479f498c74b0a79a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Enemy Scripts/Base_BossCombat.cs
+++ b/_Enemy Scripts/Base_BossCombat.cs
@@ -405,6 +405,8 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         defense = 999;
         movement.canMove = false;
         canAttack = false;
+
+        CleanseDebuffs();
         
         yield return new WaitForSeconds(1.5f);
         animator.PlayManualAnim(6, 1.083f); //Buff anim
@@ -420,6 +422,18 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         isAttacking = false;
         canAttack = true;
         changingPhase = false;
+    }
+
+    protected virtual void CleanseDebuffs()
+    {
+        int totalChildren = transform.childCount;
+        for(int i=0; i<totalChildren; i++)
+        {
+            Base_DamageOverTime currDebuff = transform.GetChild(i).GetComponent<Base_DamageOverTime>();
+
+            if(currDebuff != null) currDebuff.CleanseDebuff();
+            //make sure index is correct
+        }
     }
 
 #endregion

--- a/_Enemy Scripts/Base_BossCombat.cs
+++ b/_Enemy Scripts/Base_BossCombat.cs
@@ -468,7 +468,12 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         float totalDamage = damageTaken - defense;
 
         //Damage can never be lower than 1
-        if (totalDamage <= 0) totalDamage = 1;
+        if (totalDamage <= 0)
+        {
+            if(changingPhase) totalDamage = 0;
+            else totalDamage = 1;
+        }
+
         InstantiateManager.Instance.HitEffects.ShowHitEffect(hitEffectsOffset.position);
         currentHP -= totalDamage;
         healthBar.UpdateHealth(currentHP);

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -557,7 +557,8 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
 
         //Base_EnemyAnimator checks for isAlive to play Death animation
         isAlive = false;
-        GameManager.Instance.AugmentInventory.OnKill(hitEffectsOffset);
+        // GameManager.Instance.AugmentInventory.OnKill(hitEffectsOffset);
+        GameManager.Instance.AugmentInventory.OnKill(GetGroundPosition());
         if(enemyStageManager != null) enemyStageManager.UpdateEnemyCount();
 
         //Disable sprite renderer before deleting gameobject

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -445,12 +445,14 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
     public virtual void TakeDamage(float damageTaken, bool knockback = false, bool procOnHit = false, float strength = 8, float xPos = 0)
     {
         if (!isAlive || isSpawning) return;
-        if (damageImmune) return;
+        if (damageImmune || damageTaken <= 0) return;
 
         HitFlash(); //Set material to white, short delay before resetting
         if(procOnHit) GameManager.Instance.AugmentInventory.OnHit(hitEffectsOffset);
 
         float totalDamage = damageTaken - defense;
+
+
 
         //Damage can never be lower than 1
         if (totalDamage <= 0) totalDamage = 1;
@@ -482,21 +484,17 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         // TakeDamage(damageTaken, false, false);
 
         if (!isAlive || isSpawning) return;
-        if (damageImmune) return;
+        if (damageImmune || damageTaken <= 0) return;
 
         HitFlash(); //Set material to white, short delay before resetting
 
-        float totalDamage = damageTaken - defense;
-
-        //Damage can never be lower than 1
-        if (totalDamage <= 0) totalDamage = 1;
         InstantiateManager.Instance.HitEffects.ShowHitEffect(hitEffectsOffset.position);
-        currentHP -= totalDamage;
+        currentHP -= damageTaken;
         healthBar.UpdateHealth(currentHP);
         if(playAudioClips != null) playAudioClips.PlayRandomClip();
 
         //Display Damage number
-        InstantiateManager.Instance.TextPopups.ShowStatusDamage(totalDamage, textPopupOffset.position, colorIdx);
+        InstantiateManager.Instance.TextPopups.ShowStatusDamage(damageTaken, textPopupOffset.position, colorIdx);
 
         if (currentHP <= 0)
         {

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using Unity.Mathematics;
 using UnityEngine;
 
 public class ColossalBoss_EnemyCombat : Base_BossCombat
@@ -596,6 +595,8 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
         defense = 999;
         movement.canMove = false;
         canAttack = false;
+
+        CleanseDebuffs();
         
         yield return new WaitForSeconds(1.5f);
         animator.PlayManualAnim(6, 1.083f); //Buff anim

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -636,6 +636,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
         healthBar.gameObject.SetActive(false);
         isAlive = false;
 
+
         //Attack Coroutine checks
         if(AttackingCO != null) StopCoroutine(AttackingCO);
         StopAllCoroutines();
@@ -654,6 +655,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
         Invoke("ToggleHitbox", 1f); //Delay rb and collider toggle
 
         playDeathAnim = true;
+        CleanseDebuffs();
 
         //Show death effects then spawn XP Orbs
         ScreenShakeListener.Instance.Shake(3);

--- a/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs
@@ -113,12 +113,14 @@ public class Dagger_Lunge : Base_CombatBehavior
         movement.canMove = false;
         combat.chasePlayer = false;
 
+        movement.ToggleFlip(false);
         combat.animator.PlayManualAnim(2, fullAnimTimes[2]);
         yield return new WaitForSeconds(animDelayTimes[2]);
         CheckHit(2);
         yield return new WaitForSeconds(fullAnimTimes[2] - animDelayTimes[2]);
 
         yield return new WaitForSeconds(attackSpeed);
+        movement.ToggleFlip(true);
 
         combat.isAttacking = false;
         combat.altAttacking = false;

--- a/_Enemy Scripts/ProjectileController.cs
+++ b/_Enemy Scripts/ProjectileController.cs
@@ -61,7 +61,7 @@ public class ProjectileController : MonoBehaviour
             var target = collision.GetComponent<Base_EnemyCombat>();
             if(target != null)
             {
-                target.TakeDamageStatus(damage, 3);
+                target.TakeDamageStatus(damage, 0);
                 DestroyProjectile();
                 target.GetKnockback(!playerToRight, knockbackStrength);
             }

--- a/_Enemy Scripts/Tier 2 Enemies/Shielder_EnemyCombat.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Shielder_EnemyCombat.cs
@@ -78,10 +78,9 @@ public class Shielder_EnemyCombat : Base_EnemyCombat
         GetComponent<CapsuleCollider2D>().enabled = false;
 
         isAlive = false;
-        GameManager.Instance.AugmentInventory.OnKill(transform);
+        GameManager.Instance.AugmentInventory.OnKill(GetGroundPosition());
         ScreenShakeListener.Instance.Shake(2);
         //InstantiateManager.Instance.HitEffects.ShowKillEffect(hitEffectsOffset.position);
-
 
         StartCoroutine(DelayDeath());
     }

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -384,14 +384,14 @@ public class Base_PlayerCombat : MonoBehaviour
     }
 
     // public void GetKnockback(bool enemyToRight, float strength = 4, float recoveryDelay = .15f)
-    public void GetKnockback(float enemyXPos, float strength = 4, float recoveryDelay = .15f)
+    public void GetKnockback(float enemyXPos, float kbForce = 4, float recoveryDelay = .15f)
     {
         if (!isAlive || dashImmune) return;
         if(isParrying) return;
         KnockbackNullCheckCO();
 
-        if (kbResist > 0) strength -= kbResist;
-        if (strength <= 0) return;
+        if (kbResist > 0) kbForce -= kbResist;
+        if (kbForce <= 0) return;
 
         isKnockedback = true;
 
@@ -399,23 +399,23 @@ public class Base_PlayerCombat : MonoBehaviour
         kbToRight = enemyXPos < transform.position.x;
         // if(enemyXPos < transform.position.x) kbToRight = false;
 
-        KnockbackCO = StartCoroutine(Knockback(kbToRight, strength, recoveryDelay));
+        KnockbackCO = StartCoroutine(Knockback(kbToRight, kbForce, recoveryDelay));
         // float temp = enemyToRight != true ? 1 : -1; //get knocked back in opposite direction of player
         // Vector2 direction = new Vector2(temp, .3f);
         // movement.rb.AddForce(direction * strength, ForceMode2D.Impulse);
     }
 
-    public void GetKnockback(bool kbToRight, float strength = 4, float recoveryDelay = .15f)
+    public void GetKnockback(bool kbToRight, float kbForce = 4, float recoveryDelay = .15f)
     {
         if (!isAlive || dashImmune) return;
         KnockbackNullCheckCO();
 
-        if (kbResist > 0) strength -= kbResist;
-        if (strength <= 0) return; //Full knockback resist
+        if (kbResist > 0) kbForce -= kbResist;
+        if (kbForce <= 0) return; //Full knockback resist
 
         isKnockedback = true;
 
-        KnockbackCO = StartCoroutine(KnockbackManual(kbToRight, strength, recoveryDelay));
+        KnockbackCO = StartCoroutine(KnockbackManual(kbToRight, kbForce, recoveryDelay));
     }
 
     IEnumerator Knockback(bool kbToRight, float strength = 4, float recoveryDelay = .15f)

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -328,6 +328,11 @@ public class Base_PlayerCombat : MonoBehaviour
         }
     }
 
+    public float GetMultipliedDamage()
+    {
+        return groundAttackDamageMultipliers[currentAttack - 1] * attackDamage;
+    }
+
     void ParryCounter()
     {
         parryDeflecting = true;

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -15,7 +15,7 @@ public class Base_PlayerCombat : MonoBehaviour
     //[SerializeField] private Transform attackPoint;
     //[SerializeField] private float attackRange;
     [SerializeField] private Transform textPopupOffset;
-    [SerializeField] HealthBar healthBar;
+    [SerializeField] protected HealthBar healthBar;
     [SerializeField] private bool showGizmos = false;
 
     public HitStop hitStop; //Stops time, hitStop animations are separate
@@ -26,19 +26,19 @@ public class Base_PlayerCombat : MonoBehaviour
 
     [Space(10)]
     [Header("- Hitboxes -")]
-    [SerializeField] float attackMoveDelay = .0f;
-    [SerializeField] Transform[] attackPoints;
+    [SerializeField] protected float attackMoveDelay = .0f;
+    [SerializeField] protected Transform[] attackPoints;
     //G1(.56, .294), G2/A1(.437, .149), G3(.318, .144), A2(.479, .208)
     [SerializeField] float[] hitBoxLength; //.95f, 1.35f, 1.75f, 1.35f, 1.52f
     [SerializeField] float[] hitBoxHeight; //.63f, 0.25f, 0.25f, 0.25f, 0.28f
     
     [Space(10)]
     [Header("- Parry -")]
-    [SerializeField] Transform parryPoint;
-    [SerializeField] float parryHitBoxLength; //.64f
-    [SerializeField] float parryHitboxHeight; //.61f   
-    [SerializeField] float parryHitAddProcChance = .2f;
-    [SerializeField] float parryShieldDuration = .3f;
+    [SerializeField] protected Transform parryPoint;
+    [SerializeField] protected float parryHitBoxLength; //.64f
+    [SerializeField] protected float parryHitboxHeight; //.61f   
+    [SerializeField] protected float parryHitAddProcChance = .2f;
+    [SerializeField] protected float parryShieldDuration = .3f;
     [SerializeField] GameObject parryImmuneTextUI;
     [SerializeField] GameObject parryImmuneShield;
 
@@ -75,7 +75,7 @@ public class Base_PlayerCombat : MonoBehaviour
     public float currentHP;
     public float defense;
     public float kbResist; //Knockback resist
-    private float base_kbResist;
+    protected float base_kbResist;
 
     [SerializeField]
     public float attackDamage,
@@ -84,24 +84,30 @@ public class Base_PlayerCombat : MonoBehaviour
         critMultiplier,
         knockbackStrength;
 
+    [Space(10)]
+    [Header("- Debugging - Base Stats")]
+    [SerializeField] public float base_attackDamage;
+    [SerializeField] public float base_attackSpeed;
+
+    [Space(10)]
     //Attack Bools and Counters
     public int currAttackIndex; //Used to reference hitboxes
     public int currentAttack;
     public int currentAirAttack;
-    float timeSinceAttack;
-    float timeSinceAirAttack; //only for move check, not attack speed
-    float timeSinceBlock;
+    protected float timeSinceAttack;
+    protected float timeSinceAirAttack; //only for move check, not attack speed
+    protected float timeSinceBlock;
     public bool isAttacking;
     public bool isAirAttacking;
     [SerializeField] public bool isParrying;
-    [SerializeField] private float parryShieldTimer;
+    [SerializeField] protected float parryShieldTimer;
 
     public float blockAttackSpeed;
 
     [Space(10)]
     [Header("- Bools -")]
-    [SerializeField] bool dashImmune;
-    [SerializeField] bool damageImmune;
+    [SerializeField] protected bool dashImmune;
+    [SerializeField] protected bool damageImmune;
     //Bools
     public bool isStunned;
     public bool isAlive;
@@ -116,7 +122,7 @@ public class Base_PlayerCombat : MonoBehaviour
     Coroutine KnockbackResetCO;
 
 
-    void Start()
+    protected void Start()
     {
         sr = GetComponentInChildren<SpriteRenderer>();
         mDefault = sr.material;
@@ -135,6 +141,10 @@ public class Base_PlayerCombat : MonoBehaviour
             critMultiplier = character.Base_CritMultiplier;
             knockbackStrength = character.Base_KnockbackStrength;
         }
+
+        base_attackDamage = attackDamage;
+        base_attackSpeed = attackSpeed;
+
         currentHP = maxHP;
         if (healthBar != null) healthBar.SetHealth(maxHP);
 

--- a/_Status Effects/Base_AoE_Explosion.cs
+++ b/_Status Effects/Base_AoE_Explosion.cs
@@ -15,6 +15,7 @@ public class Base_AoE_Explosion : MonoBehaviour
     [Header("-----")]
     [SerializeField] protected LayerMask enemyLayer;
     [SerializeField] public float damage;
+    [SerializeField] protected bool statusDamage = true; //can't be blocked
     [SerializeField] protected Transform optionalHitBoxOffset;
     [SerializeField] protected float hitboxWidth;
     [SerializeField] protected float hitBoxHeight;
@@ -65,7 +66,9 @@ public class Base_AoE_Explosion : MonoBehaviour
             IDamageable damageable = enemy.GetComponent<IDamageable>();
             if(damageable == null) return;
         
-            damageable.TakeDamage(damage, true, false, knockbackStrength);
+            if(statusDamage) damageable.TakeDamageStatus(damage, 0);
+            else damageable.TakeDamage(damage, true, false, knockbackStrength, transform.position.x);
+
             ScreenShakeListener.Instance.Shake(2);
             // Transform enemyHitOffset = damageable.GetPosition();
             Transform enemyHitOffset;

--- a/_Status Effects/Base_AoE_Explosion.cs
+++ b/_Status Effects/Base_AoE_Explosion.cs
@@ -9,11 +9,13 @@ public class Base_AoE_Explosion : MonoBehaviour
     [Header("Animator")]
     [SerializeField] protected Animator animator;
     [SerializeField] protected int hashedAnimName;
+    [SerializeField] protected float animDelay = 0;
     [SerializeField] protected float animDuration;
 
     [Header("-----")]
     [SerializeField] protected LayerMask enemyLayer;
     [SerializeField] public float damage;
+    [SerializeField] protected Transform optionalHitBoxOffset;
     [SerializeField] protected float hitboxWidth;
     [SerializeField] protected float hitBoxHeight;
     [SerializeField] protected float knockbackStrength = 4f;
@@ -24,48 +26,62 @@ public class Base_AoE_Explosion : MonoBehaviour
 
     [Header("- optional -")]
     [SerializeField] protected bool attachStatusToEnemy = true;
+    [SerializeField] protected bool setStatusToGround = true;
 
     protected virtual void Start()
     {
         if(animator == null) animator = GetComponent<Animator>();
         if(animDuration > 0) animator.Play(hashedAnimName);
-        Explode();
+
+        // CheckExplodeHit();
+        // StartCoroutine(DelayedExplodeCO());
+
+        if(optionalHitBoxOffset == null) optionalHitBoxOffset = transform;
+        
+        Invoke("CheckExplodeHit", animDelay);
         Invoke("DeleteObject", animDuration); //delete object after the animation is over
     }
 
-    protected virtual void Explode()
+    // protected virtual IEnumerator DelayedExplodeCO()
+    // {
+    //     yield return new WaitForSeconds(animDelay);
+    //     CheckExplodeHit();
+    //     // yield return new WaitForSeconds(animDuration - animDelay);
+    // }
+
+    protected virtual void CheckExplodeHit()
     {
         // attackPoint = 
 
         //Only affects enemies within hitbox range
         Collider2D[] hitEnemies = 
-            Physics2D.OverlapBoxAll(transform.position,
+            Physics2D.OverlapBoxAll(optionalHitBoxOffset.position,
             new Vector2(hitboxWidth, hitBoxHeight), 0, enemyLayer);
 
         //if (damageMultiplier > 1) knockbackStrength = 6; //TODO: set variable defintion in Inspector
         
-
         foreach (Collider2D enemy in hitEnemies)
         {
             IDamageable damageable = enemy.GetComponent<IDamageable>();
-            if(damageable != null)
-            {
-                damageable.TakeDamage(damage, true, false, knockbackStrength);
-                ScreenShakeListener.Instance.Shake(2);
-                // Transform enemyHitOffset = damageable.GetPosition();
-                Transform enemyHitOffset = damageable.GetGroundPosition();
+            if(damageable == null) return;
+        
+            damageable.TakeDamage(damage, true, false, knockbackStrength);
+            ScreenShakeListener.Instance.Shake(2);
+            // Transform enemyHitOffset = damageable.GetPosition();
+            Transform enemyHitOffset;
+            
+            if(setStatusToGround) enemyHitOffset = damageable.GetGroundPosition();
+            else enemyHitOffset = damageable.GetHitPosition();
 
-                if(statusEffectPrefab != null)
-                {
-                    if(attachStatusToEnemy)
-                    {
-                        Instantiate(statusEffectPrefab, enemyHitOffset.position, statusEffectPrefab.transform.rotation, enemy.transform);
-                    }
-                    else
-                    {
-                        Instantiate(statusEffectPrefab, enemyHitOffset.position, enemyHitOffset.transform.rotation);
-                    }
-                }
+            if(statusEffectPrefab == null) return;
+            
+            if(attachStatusToEnemy)
+            {
+                Instantiate(statusEffectPrefab, enemyHitOffset.position, statusEffectPrefab.transform.rotation, enemy.transform);
+            }
+            else
+            {
+                Instantiate(statusEffectPrefab, enemyHitOffset.position, enemyHitOffset.transform.rotation);
             }
         }
     }
@@ -79,8 +95,8 @@ public class Base_AoE_Explosion : MonoBehaviour
     {
         if (showGizmos)
         {
-            Gizmos.DrawWireCube(transform.position, 
-                new Vector3((hitboxWidth),
+            Gizmos.DrawWireCube(optionalHitBoxOffset.position, 
+                new Vector3(hitboxWidth,
                 hitBoxHeight, 0));
         }
     }

--- a/_Status Effects/Base_DamageOverTime.cs
+++ b/_Status Effects/Base_DamageOverTime.cs
@@ -101,7 +101,7 @@ public class Base_DamageOverTime : MonoBehaviour
         }
     }
 
-    protected void DealDamage()
+    protected virtual void DealDamage()
     {
         if(enemyCombat != null) enemyCombat.TakeDamageStatus(damagePerTick, damageColorIdx);
         if(playerCombat != null) playerCombat.TakeDamage(damagePerTick);

--- a/_Status Effects/Base_DamageOverTime.cs
+++ b/_Status Effects/Base_DamageOverTime.cs
@@ -108,6 +108,12 @@ public class Base_DamageOverTime : MonoBehaviour
         if(enemyCombat == null && playerCombat == null) isActive = false;
     }
 
+    public virtual void CleanseDebuff()
+    {
+        isActive = false;
+        StartCoroutine(EndStatus());
+    }
+
     protected IEnumerator EndStatus(float endDelay = 1)
     {
         endingStatus = true;

--- a/_Status Effects/Base_Spawn_AoE.cs
+++ b/_Status Effects/Base_Spawn_AoE.cs
@@ -9,6 +9,7 @@ public class Base_Spawn_AoE : MonoBehaviour
     [SerializeField] public bool statusDamage = true;
     [SerializeField] public float knockbackStrength = 1;
     [SerializeField] public bool canProcOnHit = true;
+    [SerializeField] protected GameObject explosionParentOffset;
 
     [Header("HitBox")]
     [SerializeField] protected LayerMask enemyLayer;
@@ -30,6 +31,7 @@ public class Base_Spawn_AoE : MonoBehaviour
     
     protected void OnEnable() //TODO: or Start(), OnEnable() if pooling
     {
+        if(explosionParentOffset == null) explosionParentOffset = gameObject;
         StartCoroutine(Attack());
     }
 
@@ -41,7 +43,8 @@ public class Base_Spawn_AoE : MonoBehaviour
         CheckHit();
 
         yield return new WaitForSeconds(fullAnimTime - animDelayTime);
-        Destroy(gameObject);
+
+        Destroy(explosionParentOffset);
     }
 
     protected virtual void CheckHit()

--- a/_Status Effects/Base_Spawn_AoE.cs
+++ b/_Status Effects/Base_Spawn_AoE.cs
@@ -6,6 +6,7 @@ public class Base_Spawn_AoE : MonoBehaviour
 {
     [Header("Setup")]
     [SerializeField] public float damage = 5;
+    [SerializeField] public bool statusDamage = true;
     [SerializeField] public float knockbackStrength = 1;
     [SerializeField] public bool canProcOnHit = true;
 
@@ -57,7 +58,9 @@ public class Base_Spawn_AoE : MonoBehaviour
             IDamageable damageable = enemy.GetComponent<IDamageable>();
             if(damageable != null)
             {
-                damageable.TakeDamage(damage, true, canProcOnHit, knockbackStrength);
+                if(statusDamage) damageable.TakeDamageStatus(damage, 0);
+                else damageable.TakeDamage(damage, true, canProcOnHit, knockbackStrength, transform.position.x);
+
                 ScreenShakeListener.Instance.Shake(1); //TODO: if Crit
             }
         }

--- a/_Status Effects/Burn_DamageOverTime.cs
+++ b/_Status Effects/Burn_DamageOverTime.cs
@@ -1,0 +1,98 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Burn_DamageOverTime : Base_DamageOverTime
+{
+    [Header("- Burn -")]
+    // [SerializeField] private float extendTimer = 2;
+    //
+    [SerializeField] private float damageIncreasePerTick = 1;
+    [SerializeField] private float damagePerSecond = 1;
+    [SerializeField] private float maxDamagePerTick = 10;
+    [SerializeField] List<Burn_DamageOverTime> existingBurns;
+
+    protected override void Start()
+    {
+        existingBurns = new List<Burn_DamageOverTime>();
+
+        base.Start();
+        CheckForExistingDoT();
+    }
+
+    protected override void CheckForExistingDoT()
+    {
+        int totalBurns = 0;
+
+        for(int i=0; i<transform.parent.childCount; i++)
+        {
+            Burn_DamageOverTime currBurn = transform.parent.GetChild(i).GetComponent<Burn_DamageOverTime>();
+
+            //Only longer duration if target is already poisoned
+            if(currBurn != null)
+            {
+                existingBurns.Add(currBurn);
+                totalBurns++;
+            }
+            if(totalBurns > 1)
+            {
+                existingBurns[0].ResetTimer(); //Reset local duration
+
+                isActive = false;
+            }
+        }
+    }
+
+    protected override void FixedUpdate()
+    {
+        // base.FixedUpdate();
+
+        if(isActive)
+        {
+            overallTimer -= Time.deltaTime;
+            if(overallTimer <= 0) //+1 to allow for 1s delay
+            {
+                isActive = false;
+                return;
+            }
+
+            tickTimer -= Time.deltaTime; //Countdown timer
+
+            if(tickTimer <= 0) //
+            {
+                DealDamage();
+                tickTimer = tickFrequency; //Reset tick timer
+            }
+        }
+        else
+        {
+            if(endingStatus) return;
+            StartCoroutine(EndStatus());
+        }
+    }
+
+    protected override void DealDamage()
+    {
+        float damageDealt = UpdateDamage();
+
+        if(enemyCombat != null) enemyCombat.TakeDamageStatus(damageDealt, damageColorIdx);
+        if(playerCombat != null) playerCombat.TakeDamage(damageDealt);
+        if(enemyCombat == null && playerCombat == null) isActive = false;
+    }
+
+    float UpdateDamage()
+    {
+        float totalDamage = Mathf.FloorToInt(overallTimer / damagePerSecond) * damageIncreasePerTick;
+        existingBurns[0].SetDamagePerTick(totalDamage);
+
+        return totalDamage;
+    }
+
+    public void SetDamagePerTick(float addDamagePerTick)
+    {
+        damagePerTick = addDamagePerTick;
+        //Damage cannot exceed max
+        if(damagePerTick > maxDamagePerTick)
+            damagePerTick = maxDamagePerTick;
+    }
+}

--- a/_Status Effects/Burn_DamageOverTime.cs.meta
+++ b/_Status Effects/Burn_DamageOverTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d6e0758e8325924eb22e6d0fcdf5e90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Status Effects/Spawn_AoE_Explosion.cs
+++ b/_Status Effects/Spawn_AoE_Explosion.cs
@@ -7,7 +7,7 @@ public class Spawn_AoE_Explosion : Base_AoE_Explosion
     [Header("= Spawn Only =")]
     [SerializeField] Transform hitboxOffset;
 
-    protected override void Explode()
+    protected override void CheckExplodeHit()
     {
         // base.Explode();
         Collider2D[] hitEnemies = 

--- a/_UI Scripts/HealthBar.cs
+++ b/_UI Scripts/HealthBar.cs
@@ -72,6 +72,6 @@ public class HealthBar : MonoBehaviour
         lerpTimer = 0f;
 
         if(healthNumbers != null)
-            healthNumbers.text = currentHealth + " / " + maxHealth;
+            healthNumbers.text = currentHealth.ToString("N0") + " / " + maxHealth.ToString("N0");
     }
 }


### PR DESCRIPTION
### Augments
- New Augments
  - **Smite** - On-Kill: chance for lighting to strike nearby enemies, enemies caught in the initial strike are stuck again
  - **Riposte** - On-Parry: chance to proc On-Kill augments
  - **Retaliate** - On-Parry: chance to proc On-Hit augments
  - **Ruin** - On-Hit: chance to proc On-Kill augments, player base damage reduced to 1, max health reduced by 20
  - **Sunder** - On-Hit: chance to deal double damage of current attack, can double Sharpened damage
- Added visual for Repel augment activation
- Sharpen changed from permanent damage buff to a On-Hit duration buff
- Re-arranged Augments to new rarities
- Burn Status effect now deals increased damage per second left on the timer
  - Higher timer deals higher damage per tick, damage lowers as timer runs out

### Player
- Successful Parries now give the Player a short damage and knockback immunity shield
  - Added visual shield to the Player
  - Added Parry Shield overlay over the Player health bar
- Parry can now proc On-Hit effects with an increased chance

### Misc
- Updated explosion augments and status effects to use either the hitOffset or groundPosition of the target
- Colossal Boss now cleanses all status effects when reaching a new health phase
- Updated platform layouts for all rooms for Archer enemy
- Updated platforms for Trial rooms

### Fixes
- Fixed OnKill effects being offset for Drone and Shielder
- Fixed Shielder blocking Echo and certain explosions
- Fixed Augments displaying levels above their max