### PR TITLE
Minimap Icons, more Augment Rewards, Archer update

### DIFF
--- a/DEBUGGING_MODE.cs
+++ b/DEBUGGING_MODE.cs
@@ -31,7 +31,12 @@ public class DEBUGGING_MODE : MonoBehaviour
             playerCombat.kbResist = 9999;
         }
 
-        if(Input.GetKey(KeyCode.LeftShift))
+        if (Input.GetKeyDown(KeyCode.Y))
+        {
+            playerCombat.HealPlayer(20f);
+        }
+
+        if(Input.GetKey(KeyCode.RightShift))
         {
             if(Input.GetKeyDown(KeyCode.R))
             {
@@ -70,7 +75,7 @@ public class DEBUGGING_MODE : MonoBehaviour
         if (showGizmos)
         {
             Gizmos.DrawWireCube(transform.position, 
-                new Vector3((hitboxWidth),
+                new Vector3(hitboxWidth,
                 hitBoxHeight, 0));
         }
     }

--- a/ShopController.cs
+++ b/ShopController.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public class ShopController : MonoBehaviour
 {
+    [Header("- Shop Minimap icon -")]
+    [SerializeField] SpriteRenderer shopMinimapIcon;
+
     [Header("Testing")]
     [SerializeField] private bool DEBUGGING = false;
     [Space(10)]
@@ -106,5 +109,12 @@ public class ShopController : MonoBehaviour
     {
         int totalOwnedAugments = augmentPool.ownedAugments.Count;
         return totalOwnedAugments < 3;
+    }
+
+    public void SetPurchaseDone()
+    {
+        oneTimePurchaseDone = true;
+        if(oneTimePurchaseDone && shopMinimapIcon != null)
+            shopMinimapIcon.color = new Color32(70, 70, 70, 200);
     }
 }

--- a/_Audio/AudioManager.cs
+++ b/_Audio/AudioManager.cs
@@ -27,6 +27,8 @@ public class AudioManager : MonoBehaviour
 
     public void PlaySound(AudioClip clip)
     {
+        //Check if sound is already playing, stop current sound then play new one
+        if(sfxSource.isPlaying) sfxSource.Stop();
         sfxSource.PlayOneShot(clip);
     }
 

--- a/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs
+++ b/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs
@@ -88,7 +88,7 @@ public class AugmentDisplay_HealOnly : AugmentDisplay
 
         //Need to manually set purchase here, others are set through AugmentSelectMenu
         if(shopController != null)
-            shopController.oneTimePurchaseDone = true; 
+            shopController.SetPurchaseDone();
     }
 
 }

--- a/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs
+++ b/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class AugmentDisplay_HealOnly : AugmentDisplay
 {
     [Header("- Heal Shop Only -")]
+    [SerializeField] ShopController shopController;
     [SerializeField] protected float healAmountLower = 10;
     [SerializeField] protected float healAmountUpper = 30;
     [SerializeField] string healItemName = "";
@@ -84,6 +85,10 @@ public class AugmentDisplay_HealOnly : AugmentDisplay
         // selectMenu.SelectAugment(augmentScript, randomizeLevel);
         ToggleOverlay(true);
         selectMenu.CloseSelectMenu();
+
+        //Need to manually set purchase here, others are set through AugmentSelectMenu
+        if(shopController != null)
+            shopController.oneTimePurchaseDone = true; 
     }
 
 }

--- a/_Augments/Alternate Shops/AugmentSelectMenu_Blood.cs
+++ b/_Augments/Alternate Shops/AugmentSelectMenu_Blood.cs
@@ -29,14 +29,14 @@ public class AugmentSelectMenu_Blood : AugmentSelectMenu
         augmentSelected = true;
 
         if(shopController != null)
-            shopController.oneTimePurchaseDone = true;
+            shopController.SetPurchaseDone();
 
         StartCoroutine(DisableSelectMenu(.5f));
     }
 
     protected override int GetPrice(AugmentScript augment)
     {
-        int totalHealthCost = 0;
+        int totalHealthCost;
 
         switch(augment.Tier)
         {

--- a/_Augments/Augment.cs
+++ b/_Augments/Augment.cs
@@ -20,8 +20,8 @@ public class Augment : ScriptableObject
     public _AugmentType AugmentType;
 
     // public enum _MaxLevel { Level1 = 1, Level2 = 2, Level3 = 3, Level4 = 5, Level5 = 5};
-    // public _MaxLevel MaxLevel; //TODO: might not use this system //FIX: Level5 can't be selected
-    public int MaxLevel = 5; //TODO: might not use this system
+    // public _MaxLevel MaxLevel;
+    public int MaxLevel = 5;
 
     public Sprite AugmentIcon;
     public string Name;

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using UnityEditor.Rendering;
 
 public class AugmentScript : MonoBehaviour
 {
@@ -183,30 +184,34 @@ public class AugmentScript : MonoBehaviour
 
         if(augmentScrObj != null)
         {
+            string tempDesc; //Initial description before setting as main
             if(random)
             {
                 string buffedDesc = "?" + divider;
-                Description = baseDescription.Replace('#'.ToString(), buffedDesc);
+                tempDesc = baseDescription.Replace('#'.ToString(), buffedDesc);
+
                 if(isConditional)
                 {
-                    string tempDesc = Description;
                     Description = tempDesc.Replace('$'.ToString(), '?'.ToString());
-
-                    // Description = Description.Replace('$', '?');
-                    Description = baseDescription.Replace('$'.ToString(), '?'.ToString());
+                }
+                else
+                {
+                    Description = tempDesc;
                 }
             }else{
                 string buffedDesc = stat.ToString() + divider;
-                Description = baseDescription.Replace('#'.ToString(), buffedDesc);
+                tempDesc = baseDescription.Replace('#'.ToString(), buffedDesc);
+
                 if(isConditional)
                 {
                     float procDesc = procChance*100f;
-                    // Description = Description.Replace('$', procStr);
-                    Description = baseDescription.Replace('$'.ToString(), procDesc.ToString("N0")); 
+                    Description = tempDesc.Replace('$'.ToString(), procDesc.ToString("N0")); 
+                }
+                else
+                {
+                    Description = tempDesc;
                 }
             }
-            // string conditionalDesc = conditionalBuffedAmount.ToString();
-            // Description = baseDescription.Replace('@'.ToString(), conditionalDesc);
         }
     }
 

--- a/_Augments/AugmentSelectMenu.cs
+++ b/_Augments/AugmentSelectMenu.cs
@@ -157,7 +157,7 @@ public class AugmentSelectMenu : MonoBehaviour
         augmentSelected = true;
 
         if(shopController != null)
-            shopController.oneTimePurchaseDone = true;
+            shopController.SetPurchaseDone();
 
         StartCoroutine(DisableSelectMenu(.5f));
     }

--- a/_Augments/Conditional/CA_OnHit_OnKill.cs
+++ b/_Augments/Conditional/CA_OnHit_OnKill.cs
@@ -26,9 +26,14 @@ public class CA_OnHit_OnKill : Base_ConditionalAugments
     {
         // base.Activate();
         if(!CanActivate()) return;
-        StartProcCooldown();
 
-        GameManager.Instance.AugmentInventory.OnKill(objectHitPos, onHitAddProcChance);   
+        Base_EnemyCombat enemyHit = objectHitPos.GetComponent<Base_EnemyCombat>();
+        Transform groundOffset;
+        if(enemyHit != null) groundOffset = enemyHit.GetGroundPosition();
+        else groundOffset = objectHitPos;
+
+        StartProcCooldown();
+        GameManager.Instance.AugmentInventory.OnKill(groundOffset, onHitAddProcChance);   
     }
 
     public override void SetConditionalAugmentStats()

--- a/_Enemy Scripts/Base_EnemyCombat.cs
+++ b/_Enemy Scripts/Base_EnemyCombat.cs
@@ -453,7 +453,6 @@ public class Base_EnemyCombat : MonoBehaviour, IDamageable
         float totalDamage = damageTaken - defense;
 
 
-
         //Damage can never be lower than 1
         if (totalDamage <= 0) totalDamage = 1;
         InstantiateManager.Instance.HitEffects.ShowHitEffect(hitEffectsOffset.position);

--- a/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs
@@ -50,12 +50,7 @@ public class Dagger_Lunge : Base_CombatBehavior
 
     void Update()
     {
-        if(Input.GetKeyDown(KeyCode.N))
-        {
-            // TESTLUNGE();
-            combat.Lunge(movement.isFacingRight, 8);
-        }
-
+        //Timer keeps track of when to reset attack counter to first attack
         if(attackResetTimer > 0)
         {
             attackResetTimer -= Time.deltaTime;
@@ -75,11 +70,13 @@ public class Dagger_Lunge : Base_CombatBehavior
 
         movement.ToggleFlip(false);
 
-        //Attack 1
-        combat.animator.PlayManualAnim(0, fullAnimTimes[0]);
         // combat.Lunge(movement.isFacingRight, 8);
         combat.GetKnockback(movement.isFacingRight, 8); //TODO: no idea why Lunge doesn't work
-        yield return new WaitForSeconds(animDelayTimes[0]);
+        yield return new WaitForSeconds(.1f); //Lunge start before animation
+
+        //Attack 1
+        combat.animator.PlayManualAnim(0, fullAnimTimes[0]);
+        yield return new WaitForSeconds(animDelayTimes[0] - .1f);
         movement.canMove = false;
         CheckHit(0);
 

--- a/_Enemy Scripts/Enemy Behaviors/Ranged_Static.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Ranged_Static.cs
@@ -10,7 +10,10 @@ public class Ranged_Static : Base_CombatBehavior
     [SerializeField] protected Transform attackPoint;
     [SerializeField] public float damage = 4;
     [SerializeField] public bool canFire;
-    
+    [SerializeField] protected float projectileFireDelay = .3f;
+
+    [Header("- Optional Indicator -")]
+    [SerializeField] protected GameObject indicator;
 
     protected override void Start()
     {
@@ -25,6 +28,12 @@ public class Ranged_Static : Base_CombatBehavior
         StartCoroutine(ShootCO());
     }
 
+    public virtual void PlayIndicator()
+    {
+        if(indicator == null) return;
+        indicator.SetActive(true);
+    }
+
     IEnumerator ShootCO()
     {
         combat.isAttacking = true;
@@ -35,9 +44,12 @@ public class Ranged_Static : Base_CombatBehavior
         combat.knockbackImmune = true;
         // movement.rb.velocity = Vector3.zero;
 
-        yield return new WaitForSeconds(chargeUpAnimDelay); //Charge up anim
+        // yield return new WaitForSeconds(chargeUpAnimDelay); //Charge up anim
 
+        PlayIndicator();
         combat.animator.PlayManualAnim(0, fullAnimTime);
+
+        yield return new WaitForSeconds(projectileFireDelay);
 
         //Instantiate projectile, set variables from this script
         GameObject projectileObj = Instantiate(projectile, attackPoint.position, transform.rotation);
@@ -45,7 +57,7 @@ public class Ranged_Static : Base_CombatBehavior
         script.damage = damage;
         script.playerToRight = raycast.playerToRight; //Knockback direction
 
-        yield return new WaitForSeconds(fullAnimTime - chargeUpAnimDelay);
+        yield return new WaitForSeconds(fullAnimTime - chargeUpAnimDelay - projectileFireDelay);
         combat.knockbackImmune = false;
         combat.isAttacking = false;
 

--- a/_Enemy Scripts/ProjectileController.cs
+++ b/_Enemy Scripts/ProjectileController.cs
@@ -16,14 +16,14 @@ public class ProjectileController : MonoBehaviour
     [Header("References")]
     [SerializeField] Animator animator;
 
-    CircleCollider2D collider;
+    BoxCollider2D collider;
 
     protected virtual void Start()
     {
         if(animator == null) animator = GetComponent<Animator>();
         projectileHit = false;
         Invoke("DestroyProjectile", 3);
-        collider = GetComponent<CircleCollider2D>();
+        collider = GetComponent<BoxCollider2D>();
     }
 
     protected virtual void Update()

--- a/_Level Generator/LevelBuilder.cs
+++ b/_Level Generator/LevelBuilder.cs
@@ -77,7 +77,11 @@ public class LevelBuilder : MonoBehaviour
         if (DEBUGGING)
         {
             if (!builderRunning)
-                if (Input.GetKeyDown(KeyCode.U)) DeleteOrigins();
+                if (Input.GetKeyDown(KeyCode.U)) 
+                {
+                    DeleteOrigins();
+                    GameManager.Instance.RestartLevelCount();
+                }
         }
 
         if (WallGen.wallGenDone && !builderRunning) return; //Stop updating raycasts if not needed

--- a/_Level_Scene_Load/DoorController.cs
+++ b/_Level_Scene_Load/DoorController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 
 public class DoorController : MonoBehaviour
@@ -16,6 +17,12 @@ public class DoorController : MonoBehaviour
     [SerializeField] string[] animNames = { "Door_Closed", "Door_Opening", "Door_Opened" };
     [SerializeField] GameObject doorArrow; //TODO: replace with arrow
 
+    [Header("- Boss Door Only -")]
+    [SerializeField] public bool isBossDoor = false;
+    [SerializeField] GameObject DoorLockedIcon;
+    [SerializeField] GameObject[] doorLockIcons;
+    [SerializeField] TextMeshPro[] lockConditionsText;
+
     [Header("Variables")]
     public bool isOpen;
 
@@ -28,15 +35,50 @@ public class DoorController : MonoBehaviour
         //blockDropThroughCollider
         if(doorCollider != null) doorOffset = doorCollider.transform;
         ToggleOpenIndicator(false);
+
+        if(DoorLockedIcon != null)
+        {
+            DoorLockedIcon.SetActive(true);
+        }
+
+        if(isBossDoor)
+        {
+            isOpen = false;
+            GameManager.Instance.AddBossDoor(this);
+            DisplayLockIcons(true);
+        } 
     }
     
     void Update()
     {
-        //ToggleDoor(isOpen);
+        //ToggleDoor(isOpen); //debugging
+    }
+
+    public void DisplayLockIcons(bool toggle)
+    {
+        if(doorLockIcons.Length == 0 || lockConditionsText.Length == 0) return;
+        int clearedTrials = GameManager.Instance.totalTrialsCleared;
+        int totalClearsNeeded = GameManager.Instance.totalTrialsNeeded;
+
+        for(int i=0; i<doorLockIcons.Length; i++)
+        {
+            doorLockIcons[i].SetActive(toggle);
+            lockConditionsText[i].text = clearedTrials + "/" + totalClearsNeeded;
+        }
     }
 
     public void ToggleDoor(bool toggle)
     {
+        if(isBossDoor)
+        {
+            if(GameManager.Instance.CheckBossUnlock()) isOpen = true;
+            else
+            {
+                isOpen = false;
+                return;
+            }
+        }
+
         isOpen = toggle;
         if(isOpen) PlayAnim(1); //Open anim
         else PlayAnim(0); //Close anim
@@ -44,6 +86,10 @@ public class DoorController : MonoBehaviour
         if(toggle) Invoke("OpenDoorCollider", .5f);
         else Invoke("CloseDoorCollider", .1f);
         // doorCollider.isTrigger = toggle;
+        if(DoorLockedIcon != null)
+        {
+            DoorLockedIcon.SetActive(!toggle);
+        }
     }
 
     void OpenDoorCollider() //Change collider to trigger, allow dropThrough

--- a/_Level_Scene_Load/EnemyStageManager.cs
+++ b/_Level_Scene_Load/EnemyStageManager.cs
@@ -75,7 +75,7 @@ public class EnemyStageManager : MonoBehaviour
 
     public void StartTrial()
     {
-        //Separate call for Trials, manually called with interact
+        //Separate call for Trials, manually called when Player interacts with statue
         if(!trialRoom) return;
         SpawnCurrentWave();
     }
@@ -86,8 +86,8 @@ public class EnemyStageManager : MonoBehaviour
         SpawnWave();
         
         //Boss is already enabled, manually starting spawn
-        // if(bossRoom) 
-        SpawnWave();
+        // if(bossRoom)
+        // SpawnWave();
     }
 
     private void SpawnWave()
@@ -126,128 +126,4 @@ public class EnemyStageManager : MonoBehaviour
             }
         }
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-//========================================================================
-//========================================================================
-//========================================================================
-//========================================================================
-//========================================================================
-//========================================================================
-
-    // public void EnemySetup1()
-    // {
-    //     // for(int i = 0; i < transform.childCount; i++)
-    //     // {
-    //     //     if(transform.GetChild(i).CompareTag("Enemy") || transform.GetChild(i).CompareTag("Boss"))
-    //     //     {
-    //     //         //Only need the one Enemy parent object, break when found
-    //     //         enemyParentObj = transform.GetChild(i).transform;
-    //     //         break;
-    //     //     }
-    //     // }
-    //     // if (enemyParentObj != null) enemyCount = enemyParentObj.childCount;
-
-    //     // //Toggle all enemies
-    //     // if(enemyCount > 0)
-    //     // {
-    //     //     for(int i = 0; i < enemyCount; i++)
-    //     //     {
-    //     //         var enemyObj = enemyParentObj.GetChild(i).gameObject;
-    //     //         enemyObj.SetActive(false);
-    //     //         // if(enemyObj.CompareTag("Enemy")) enemyObj.SetActive(false);
-    //     //     }
-    //     // }
-
-    //     // if(bossRoom)
-    //     // {
-    //     //     var bossObj = enemyParentObj.GetChild(0);
-    //     //     bossObj.gameObject.SetActive(true);
-    //     // } 
-    // }
-
-    private void SpawnWave1()
-    {
-        //Spawn all or remaining enemies
-        // for(int i = 0; i < enemyCount + 1; i++)
-        //     enemyParentObj.GetChild(i).gameObject.SetActive(true);
-    }
-
-    private void SpawnCurrentWave1()
-    {
-        // currWaveEnemyCount = waveThreshold[currentWave];
-        int numSpawns;
-        //Spawn next # of enemies
-        //Compare wave index to total number of Waves
-        // if((currentWave - 1) < waveThreshold.Length)
-        // {
-        //     numSpawns = waveThreshold[currentWave];
-        // }
-        // else numSpawns = enemyCount + 1;
-
-        // for(int i = 0; i < numSpawns; i++)
-        // {
-        //     enemyParentObj.GetChild(i).gameObject.SetActive(true);
-        // }
-        
-        //Boss is already enabled, manually starting spawn
-        if(bossRoom)
-            enemyParentObj.GetChild(0).GetComponent<Base_BossCombat>().StartSpawn();
-    }
-
-    // private void SpawnNextWave()
-    // {
-    //     if(enemyCount <= 0) return;
-    //     //Check if index is in bounds, if not, spawn remaining enemies
-    //     if((currentWave + 1) > waveThreshold.Length)
-    //     {
-    //         //Make sure everything else is spawned here
-    //         SpawnWave();
-    //     }
-    //     else Invoke("SpawnCurrentWave", .5f);
-    // }
-    
-    // public void UpdateEnemyCount() //TODO: remove
-    // {
-    //     // if (enemyCount > 0) enemyCount--;
-    //     // // CheckWaveCount();
-    //     // if (enemyCount <= 0)
-    //     // {
-    //     //     roomManager.Cleared();
-    //     //     SpawnClearRewards();
-    //     // }
-    // }
 }

--- a/_Level_Scene_Load/EnemyStageManager.cs
+++ b/_Level_Scene_Load/EnemyStageManager.cs
@@ -7,7 +7,7 @@ public class EnemyStageManager : MonoBehaviour
 {
     //Attach this to Room Prefab that holds Platforms and Enemies parent objects
     [Header("References")]
-    public GameObject minimapIcon;
+    public SpriteRenderer minimapIcon; //Only for Shops, Trials, Boss rooms with specific icons
     [SerializeField] Transform enemyParentObj;
     // [SerializeField] int enemyCount; //number of enemies in level
     [SerializeField] int totalWaves;
@@ -62,7 +62,7 @@ public class EnemyStageManager : MonoBehaviour
     public void ToggleMinimapIcon(bool toggle)
     {
         if(minimapIcon == null) return;
-        minimapIcon.SetActive(toggle);
+        minimapIcon.gameObject.SetActive(toggle);
     }
 
 #region Spawning

--- a/_Level_Scene_Load/EnemyStageManager.cs
+++ b/_Level_Scene_Load/EnemyStageManager.cs
@@ -17,6 +17,7 @@ public class EnemyStageManager : MonoBehaviour
     [Space(20)]
     [Header("= SETUP =")]
     public bool isStartingRoom = false; //Manually set this in room Prefab
+    public bool normalRoom; //Allows room to count towards augment reward from clears
     public bool neutralRoom;
     public bool hasAugmentRewards = false;
     public bool bossRoom = false;

--- a/_Level_Scene_Load/EnemyWaveManager.cs
+++ b/_Level_Scene_Load/EnemyWaveManager.cs
@@ -24,13 +24,7 @@ public class EnemyWaveManager : MonoBehaviour
     {
         enemyCount = transform.childCount;
 
-        if(bossRoom)
-        {
-            var bossObj = transform.GetChild(0);
-            // bossObj.gameObject.SetActive(true);
-            // bossObj.GetComponent<Base_BossCombat>().StartSpawn();
-        }
-        else
+        if(!bossRoom)
         {
             //Toggle all enemies
             if(enemyCount > 0)
@@ -41,6 +35,13 @@ public class EnemyWaveManager : MonoBehaviour
                     enemyObj.SetActive(false);
                 }
             }
+        }
+        else
+        {
+            //do nothing
+            // var bossObj = transform.GetChild(0);
+            // bossObj.gameObject.SetActive(true);
+            // bossObj.GetComponent<Base_BossCombat>().StartSpawn();
         }
     }
 

--- a/_Manager Handler Scripts/GameManager.cs
+++ b/_Manager Handler Scripts/GameManager.cs
@@ -25,6 +25,11 @@ public class GameManager : MonoBehaviour
     public AugmentInventory AugmentInventory;
     public Inventory Inventory;
     public AugmentPool AugmentPool;
+    public int normalRoomClearCount;
+    public int normalRoomClearRewardLimit = 3;
+    [Header("- Debugging -")]
+    public int roomAugmentRewardsGiven; //Total augments the player has received from Normal room rewards
+    // public int[] rewardRoomCounts;
 
     private void Awake()
     {
@@ -40,6 +45,8 @@ public class GameManager : MonoBehaviour
         shopOpen = false;
         rewardOpen = false;
         inputAllowed = true;
+        normalRoomClearCount = 0;
+        roomAugmentRewardsGiven = 0;
     }
 
     private void Update()
@@ -60,5 +67,19 @@ public class GameManager : MonoBehaviour
         inputAllowed = toggle; //Referenced by Shop and Pause menus
         PlayerMovement.allowInput = toggle; //Direct set in Player scripts
         PlayerCombat.allowInput = toggle;
+    }
+
+    public bool CheckPlayerAugmentReward()
+    {
+        //Give player augments after clearing a certain number of normal rooms (not including Trials, Boss, etc)
+        //Reached Normal reward count limit
+        if(roomAugmentRewardsGiven >= normalRoomClearRewardLimit) return false;
+
+        //Checking if the number of normal room clears has reached the miletones
+        if(normalRoomClearCount == 1 || normalRoomClearCount == 3 || normalRoomClearCount == 5)
+        {
+            return true;
+        }
+        else return false; //Player hasn't reached any threshold yet
     }
 }

--- a/_Manager Handler Scripts/GameManager.cs
+++ b/_Manager Handler Scripts/GameManager.cs
@@ -30,6 +30,11 @@ public class GameManager : MonoBehaviour
     [Header("- Debugging -")]
     public int roomAugmentRewardsGiven; //Total augments the player has received from Normal room rewards
     // public int[] rewardRoomCounts;
+    [Space(10)]
+    [Header("- Boss Unlock -")]
+    public int totalTrialsCleared;
+    public int totalTrialsNeeded = 2;
+    [SerializeField] private List<DoorController> bossDoors;
 
     private void Awake()
     {
@@ -47,6 +52,18 @@ public class GameManager : MonoBehaviour
         inputAllowed = true;
         normalRoomClearCount = 0;
         roomAugmentRewardsGiven = 0;
+
+        totalTrialsCleared = 0;
+        bossDoors = new List<DoorController>();
+    }
+
+    public void RestartLevelCount()
+    {
+        //Reset room counters and level specific references
+        normalRoomClearCount = 0;
+        roomAugmentRewardsGiven = 0;
+        totalTrialsCleared = 0;
+        bossDoors = new List<DoorController>();
     }
 
     private void Update()
@@ -81,5 +98,37 @@ public class GameManager : MonoBehaviour
             return true;
         }
         else return false; //Player hasn't reached any threshold yet
+    }
+
+    public bool CheckBossUnlock()
+    {
+        // public int totalTrialsCleared;
+        // public int totalTrialsNeeded = 2;
+
+        if(totalTrialsCleared >= totalTrialsNeeded)
+        {
+            return true;
+        }
+        else return false;
+    }
+
+    public void UnlockBossDoor()
+    {
+        for(int i=0; i<bossDoors.Count; i++)
+        {
+            bossDoors[i].DisplayLockIcons(true);
+        }
+
+        if(!CheckBossUnlock()) return;
+        for(int i=0; i<bossDoors.Count; i++)
+        {
+            bossDoors[i].ToggleDoor(true);
+            bossDoors[i].DisplayLockIcons(false);
+        }
+    }
+
+    public void AddBossDoor(DoorController door)
+    {
+        bossDoors.Add(door);
     }
 }

--- a/_Manager Handler Scripts/Room Managers/CameraRoomManager.cs
+++ b/_Manager Handler Scripts/Room Managers/CameraRoomManager.cs
@@ -39,6 +39,12 @@ public class CameraRoomManager : MonoBehaviour
             roomClear.ToggleMinimapIcon(true);
             doorManager.UpdateDoorState(.05f); //Open/Close doors if room has been cleared
         }
+
+        if(collision.CompareTag("RevealRoom"))
+        {
+            //Revealing border rooms to the Player's current room
+            roomClear.RevealRoomIconOnly();
+        }
     }
 
     void OnTriggerExit2D(Collider2D collision)

--- a/_Manager Handler Scripts/Room Managers/RoomClear.cs
+++ b/_Manager Handler Scripts/Room Managers/RoomClear.cs
@@ -46,6 +46,12 @@ public class RoomClear : MonoBehaviour
         // DoorManager.DelayedRevealDoor();
     }
 
+    public void RevealRoomIconOnly()
+    {
+        if(stageManager.minimapIcon == null) return;
+        stageManager.minimapIcon.gameObject.SetActive(true);
+    }
+
     private void ToggleMinimapCleared(bool toggle)
     {
         if(minimapIcon == null) return;
@@ -72,6 +78,13 @@ public class RoomClear : MonoBehaviour
     IEnumerator DelayClear()
     {
         ToggleMinimapCleared(true);
+        if(trialRoom)
+        {
+            GameManager.Instance.totalTrialsCleared++;
+            stageManager.minimapIcon.color = new Color32(70, 70, 70, 200);
+            //464 6 46
+        }
+
         if(stageManager.normalRoom) GameManager.Instance.normalRoomClearCount++;
         yield return new WaitForSeconds(1f);
         if(stageManager == null) augmentReward.ToggleRewardSelect(false);
@@ -95,6 +108,9 @@ public class RoomClear : MonoBehaviour
         }
         yield return new WaitForSeconds(.5f);
         DoorManager.OpenAllDoors(true);
+
+        if(trialRoom) GameManager.Instance.UnlockBossDoor();
+
         StartCoroutine(DelaySlowMo());
         //TimeManager.Instance.DoSlowMotion();
         roomCleared = true;

--- a/_Manager Handler Scripts/Room Managers/RoomClear.cs
+++ b/_Manager Handler Scripts/Room Managers/RoomClear.cs
@@ -72,12 +72,26 @@ public class RoomClear : MonoBehaviour
     IEnumerator DelayClear()
     {
         ToggleMinimapCleared(true);
+        if(stageManager.normalRoom) GameManager.Instance.normalRoomClearCount++;
         yield return new WaitForSeconds(1f);
         if(stageManager == null) augmentReward.ToggleRewardSelect(false);
         else
         {
-            if(!stageManager.neutralRoom && stageManager.hasAugmentRewards && augmentReward != null) augmentReward.ToggleRewardSelect(true);
-            else if(augmentReward != null) augmentReward.ToggleRewardSelect(false);
+            if(!stageManager.neutralRoom && stageManager.hasAugmentRewards && augmentReward != null)
+            {
+                //Give Augment for rooms with augment rewards (Trials and Boss)
+                augmentReward.ToggleRewardSelect(true);
+            }
+            else if(GameManager.Instance.CheckPlayerAugmentReward())
+            { 
+                //Normal room clear reward, give augment, then update counter
+                augmentReward.ToggleRewardSelect(true);
+                GameManager.Instance.roomAugmentRewardsGiven++;
+            }
+            else if(augmentReward != null)
+            {
+                augmentReward.ToggleRewardSelect(false);
+            }
         }
         yield return new WaitForSeconds(.5f);
         DoorManager.OpenAllDoors(true);
@@ -85,8 +99,6 @@ public class RoomClear : MonoBehaviour
         //TimeManager.Instance.DoSlowMotion();
         roomCleared = true;
     }
-
-    
 
     public void CheckSpawn()
     {

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -121,7 +121,6 @@ public class Base_PlayerCombat : MonoBehaviour
     Coroutine KnockupCO;
     Coroutine KnockbackResetCO;
 
-
     protected void Start()
     {
         sr = GetComponentInChildren<SpriteRenderer>();

--- a/_Player Scripts/Base_PlayerCombat.cs
+++ b/_Player Scripts/Base_PlayerCombat.cs
@@ -178,11 +178,6 @@ public class Base_PlayerCombat : MonoBehaviour
         ParryShieldCheck();
         if (isStunned) return;
 
-        if (Input.GetKeyDown(KeyCode.Y)) //TODO: temp testing
-        {
-            HealPlayer(20f);
-        }
-
         if (movement.isDashing)
         {
             dashImmune = true;

--- a/_Status Effects/Burn_DamageOverTime.cs
+++ b/_Status Effects/Burn_DamageOverTime.cs
@@ -28,7 +28,7 @@ public class Burn_DamageOverTime : Base_DamageOverTime
         {
             Burn_DamageOverTime currBurn = transform.parent.GetChild(i).GetComponent<Burn_DamageOverTime>();
 
-            //Only longer duration if target is already poisoned
+            //Only longer duration if target is already burning
             if(currBurn != null)
             {
                 existingBurns.Add(currBurn);


### PR DESCRIPTION
### Minimap Icons
- Added Icons for Player, Shop, Trial, and Boss rooms
- Shop, Trial and Boss room icons are revealed if the Player enters a connecting room
- Boss room now has a Trial icon with unlock progress
  - Trial 0/2
  - Boss door only opens once Trials are cleared
- Trial and Shop icons are greyed out once cleared, or purchases are done

### Augments
- Player is now awarded an Augment after clearing 1, 3, and 5 Normal Rooms

### Enemies
- Removed projectile from Shielder
- Moved projectile to Archer, can be reflected
  - Increased flight speed and replaced Sprite with an Arrow
- Added short ChargeUp indicator for Archer
- Added ChargeUp Indicator for Delayed explosion

### Fixes
- Fixed Augment descriptions not updating fully when conditional augments had stat buffs and a conditional proc chance
- Fixed Heal Shop still being interactable after buying a Heal instead of an Augment