### PR TITLE
MainMenu scene added, settings update

### DIFF
--- a/_Audio/AudioManager.cs
+++ b/_Audio/AudioManager.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Xml.Schema;
 using UnityEngine;
 
 public class AudioManager : MonoBehaviour
@@ -10,7 +11,22 @@ public class AudioManager : MonoBehaviour
     [SerializeField] public bool toggleSFX;
     [SerializeField] public bool toggleMusic;
     [Header("Audio Sources")]
-    [SerializeField] public AudioSource musicSource, sfxSource;
+    [SerializeField] public AudioSource musicSource, ambientSource, sfxSource;
+    //TODO: add Ambient sound source
+    [Space(10)]
+    [Header("Audio Fade Settings")]
+    [SerializeField] float fadeDuration = 2f;
+
+    [Header("Debugging")]
+    [SerializeField] private float startVolumeMusic;
+    [SerializeField] private float startVolumeAmbient;
+    [SerializeField] private float fadeTimer;
+    [SerializeField] private bool fadingAudio;
+    [SerializeField] private bool fadingInAudio;
+    private float targetVolume;
+    
+    private float startingSetVolumeMusic;
+
 
     void Awake()
     {
@@ -22,6 +38,37 @@ public class AudioManager : MonoBehaviour
         else
         {
             Destroy(gameObject);
+        }
+
+        fadingAudio = false;
+        fadingInAudio = false;
+    }
+
+    void Start()
+    {
+        startVolumeMusic = musicSource.volume;
+        startVolumeAmbient = ambientSource.volume;
+
+        startingSetVolumeMusic = startVolumeMusic;
+
+        fadeTimer = 0;
+    }
+
+    void Update()
+    {   
+        if (fadingAudio)
+        {
+            if (fadeTimer < fadeDuration)
+            {
+                musicSource.volume = Mathf.Lerp(startVolumeMusic, targetVolume, fadeTimer / fadeDuration);
+                fadeTimer += Time.unscaledDeltaTime;
+            }
+            else
+            {
+                musicSource.volume = targetVolume;
+                fadingAudio = false;
+                fadeTimer = 0f;
+            }
         }
     }
 
@@ -40,6 +87,7 @@ public class AudioManager : MonoBehaviour
     public void ChangeMusicVolume(float value)
     {
         musicSource.volume = value;
+        startingSetVolumeMusic = value;
         // SettingsManager.Instance.musicVolume = value;
     }
 
@@ -57,5 +105,35 @@ public class AudioManager : MonoBehaviour
     public void ToggleMusic(bool toggle)
     {
         musicSource.mute = toggle;
+    }
+
+    public void FadeOutAudio()
+    {
+        // musicSource.
+        // ambientSource
+        if(!fadingAudio)
+        {
+            startVolumeMusic = musicSource.volume;
+            targetVolume = 0f;
+            fadingAudio = true;
+            fadingInAudio = false;
+        }
+    }
+
+    public void FadeInAudio()
+    {
+        if(!fadingAudio)
+        {
+            startVolumeMusic = musicSource.volume;
+            targetVolume = startingSetVolumeMusic;
+            fadingAudio = true;
+            fadingInAudio = true;
+        }
+        else
+        {
+            //Cancel Fade out
+            fadingAudio = false;
+            FadeInAudio();
+        }
     }
 }

--- a/_Audio/AudioManager.cs
+++ b/_Audio/AudioManager.cs
@@ -10,7 +10,7 @@ public class AudioManager : MonoBehaviour
     [SerializeField] public bool toggleSFX;
     [SerializeField] public bool toggleMusic;
     [Header("Audio Sources")]
-    [SerializeField] private AudioSource musicSource, sfxSource;
+    [SerializeField] public AudioSource musicSource, sfxSource;
 
     void Awake()
     {
@@ -40,11 +40,13 @@ public class AudioManager : MonoBehaviour
     public void ChangeMusicVolume(float value)
     {
         musicSource.volume = value;
+        // SettingsManager.Instance.musicVolume = value;
     }
 
     public void ChangeSFXVolume(float value)
     {
         sfxSource.volume = value;
+        // SettingsManager.Instance.sfxVolume = value;
     }
 
     public void ToggleSFX(bool toggle)

--- a/_Audio/VolumeSlider.cs
+++ b/_Audio/VolumeSlider.cs
@@ -12,8 +12,20 @@ public class VolumeSlider : MonoBehaviour
 
     void Start()
     {
-        if(isMusic) MusicSlider();
-        else SFXSlider();
+        if(isMusic)
+        {
+            float volumeLevel = AudioManager.Instance.musicSource.volume;
+            slider.value = volumeLevel;
+            sliderTextDisplay.text = (volumeLevel * 100).ToString("N0");
+            MusicSlider();
+        }
+        else 
+        {
+            float volumeLevel = AudioManager.Instance.sfxSource.volume;
+            slider.value = volumeLevel;
+            sliderTextDisplay.text = (volumeLevel * 100).ToString("N0");
+            SFXSlider();
+        }
     }
 
     void MusicSlider()

--- a/_Level_Scene_Load/AsyncLevelLoader.cs
+++ b/_Level_Scene_Load/AsyncLevelLoader.cs
@@ -173,5 +173,7 @@ public class AsyncLevelLoader : MonoBehaviour
 
         SceneManager.UnloadSceneAsync(unloadStage); //Unload MainMenu
         LoadScene(startStage);
+
+        
     }
 }

--- a/_Level_Scene_Load/AsyncLevelLoader.cs
+++ b/_Level_Scene_Load/AsyncLevelLoader.cs
@@ -8,16 +8,33 @@ public class AsyncLevelLoader : MonoBehaviour
     public static AsyncLevelLoader asyncLevelLoader;
     bool playerLoaded;
 
+    [Header("Loading Screen")]
     [SerializeField] private GameObject LoadScreen;
+    [SerializeField] private GameObject LoadingText;
     [SerializeField] private Animator LoadScreenAnim;
+    [SerializeField] private string loadingStartAnim = "LoadingFadeStart";
+    [SerializeField] private float loadScreenFadeOutDuration;
+    [SerializeField] private string loadingEndAnim = "LoadingFadeEnd";
+    [SerializeField] private float loadScreenFadeInDuration;
+    
 
+    [Space(10)]
     [SerializeField] private GameObject playerObject;
     //TODO: needs testing with new transforms
     [SerializeField] private Vector3 spawnPosition = new Vector3(0f, -3.35f, 0f ); //default: 
 
     private void Awake()
     {
-        asyncLevelLoader = this;
+        if(asyncLevelLoader == null)
+        {
+            asyncLevelLoader = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+        //
 
         if(playerObject == null)
             playerObject = GameObject.FindGameObjectWithTag("Player");
@@ -40,9 +57,9 @@ public class AsyncLevelLoader : MonoBehaviour
 
     IEnumerator InitialLoadCO()
     {
-        LoadScreenAnim.SetTrigger("StartLoop");
+        // LoadScreenAnim.SetTrigger("StartLoop");
         yield return new WaitForSeconds(.1f);
-        LoadScreenAnim.SetTrigger("End");
+        yield return EndLoadingCO();
     }
 
     public void LoadScene(string sceneName, string sceneToUnload) //TODO: manual call from menu Play(), can combine this into one script (LevelLoader)
@@ -59,7 +76,7 @@ public class AsyncLevelLoader : MonoBehaviour
     IEnumerator LoadSceneCO(string sceneName, string sceneToUnload)
     {
         //LoadScreen.SetActive(true);
-        LoadScreenAnim.SetTrigger("Start");
+        yield return StartLoadingCO();
         yield return new WaitForSeconds(.1f); //short delay to allow fade out animation to fully fade to load screen 
         //Without this delay, the player would see scenes being moved around
 
@@ -76,11 +93,9 @@ public class AsyncLevelLoader : MonoBehaviour
                 playerObject.transform.position = spawnPosition; //moves player to spawnPlatform while stages unload
         }
 
-        //TODO: this isn't working, not moving player
-
         UnloadScene(sceneToUnload);
 
-        LoadScreenAnim.SetTrigger("End");
+        yield return EndLoadingCO();
     }
 
     public void LoadScene(string sceneName)
@@ -91,7 +106,7 @@ public class AsyncLevelLoader : MonoBehaviour
 
     IEnumerator LoadSceneCO(string sceneName)
     {
-        LoadScreenAnim.SetTrigger("StartLoop");
+        // LoadScreenAnim.SetTrigger("StartLoop");
         AsyncOperation sceneToLoad = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
 
         while (!sceneToLoad.isDone)
@@ -99,7 +114,7 @@ public class AsyncLevelLoader : MonoBehaviour
             yield return null;
         }
 
-        LoadScreenAnim.SetTrigger("End");
+        yield return EndLoadingCO();
         //LoadScreen.SetActive(false);
     }
 
@@ -142,7 +157,6 @@ public class AsyncLevelLoader : MonoBehaviour
             Debug.Log("loading player");
             yield return null;
         }
-        LoadScreenAnim.SetTrigger("StartLoop");
 
         SceneManager.SetActiveScene(SceneManager.GetSceneByName("_PlayerScene"));
 
@@ -156,13 +170,18 @@ public class AsyncLevelLoader : MonoBehaviour
         //3) Unload MainMenu
         //4) Load TutorialStage
 
+        AudioManager.Instance.FadeOutAudio();
+
         StartCoroutine(StartGameCO(startStage, unloadStage));
     }
 
     IEnumerator StartGameCO(string startStage, string unloadStage)
     {
-        LoadScreenAnim.SetTrigger("Start");
-        yield return new WaitForSeconds(.3f); //TODO: placeholder, LevelLoader is being deleted when loading
+        // LoadScreenAnim.SetTrigger("Start");
+        yield return StartLoadingCO();
+        yield return new WaitForSeconds(.1f); //TODO: placeholder, LevelLoader is being deleted when loading
+        LoadingText.SetActive(true);
+
         LoadPlayer();
 
         while (!playerLoaded)
@@ -171,9 +190,73 @@ public class AsyncLevelLoader : MonoBehaviour
             yield return null;
         }
 
+        GameManager.Instance.TogglePlayerInput(false);
+
         SceneManager.UnloadSceneAsync(unloadStage); //Unload MainMenu
         LoadScene(startStage);
 
+        yield return EndLoadingCO();
+        LoadingText.SetActive(false);
+
+        GameManager.Instance.TogglePlayerInput(true);
+        AudioManager.Instance.FadeInAudio();
+    }
+
+    //
+    public void LoadMainMenu(string sceneToUnload)
+    {
+        AudioManager.Instance.FadeOutAudio();
+        GameManager.Instance.TogglePlayerInput(false);
+        StartCoroutine(LoadMainMenuCO(sceneToUnload));
+    }
+
+    IEnumerator LoadMainMenuCO(string sceneToUnload)
+    {
+        yield return StartLoadingCO();
+        // yield return new WaitForSecondsRealtime(loadScreenFadeOutDuration);
+        LoadingText.SetActive(true);
+        // yield return Unload(sceneToUnload);
+        // yield return Unload("_PlayerScene");
+
+        //Loading in Single mode unloads all other scenes
+        var mainScene = SceneManager.LoadSceneAsync("MainMenu", LoadSceneMode.Single);
         
+        while(!mainScene.isDone)
+        {
+            Debug.Log("Loading MainMenu...");
+            yield return null;
+        }
+
+        // SceneManager.LoadScene("MainMenu");
+
+        LoadingText.SetActive(false);
+        AudioManager.Instance.FadeInAudio();
+        GameManager.Instance.TogglePlayerInput(true);
+
+        yield return EndLoadingCO();
+        // yield return new WaitForSecondsRealtime(loadScreenFadeOutDuration);
+    }
+
+    //
+    // private void StartLoadingAnim()
+    // {
+    //     StartCoroutine(StartLoadingCO());
+    // }
+
+    IEnumerator StartLoadingCO()
+    {
+        LoadScreenAnim.Play(loadingStartAnim);
+        yield return new WaitForSecondsRealtime(loadScreenFadeOutDuration);
+    }
+
+    // private void EndLoadingAnim()
+    // {
+    //     StartCoroutine(EndLoadingCO());
+    // }
+
+    IEnumerator EndLoadingCO()
+    {
+        LoadScreenAnim.Play(loadingEndAnim);
+        yield return new WaitForSecondsRealtime(loadScreenFadeInDuration);
     }
 }

--- a/_Level_Scene_Load/EnemyStageManager.cs
+++ b/_Level_Scene_Load/EnemyStageManager.cs
@@ -8,6 +8,12 @@ public class EnemyStageManager : MonoBehaviour
     //Attach this to Room Prefab that holds Platforms and Enemies parent objects
     [Header("References")]
     public SpriteRenderer minimapIcon; //Only for Shops, Trials, Boss rooms with specific icons
+    [SerializeField] string lockedAnimName;
+    [SerializeField] string unlockedAnimName;
+    [SerializeField] int hashedLockedAnim;
+    [SerializeField] int hashedUnlockedAnim;
+    [SerializeField] Animator anim;
+    [Space(5)]
     [SerializeField] Transform enemyParentObj;
     // [SerializeField] int enemyCount; //number of enemies in level
     [SerializeField] int totalWaves;
@@ -57,12 +63,26 @@ public class EnemyStageManager : MonoBehaviour
         currentWaveIdx = 0;
 
         if(!isStartingRoom) ToggleMinimapIcon(false);
+
+        if(bossRoom)
+        {
+            ToggleBossUnlockIcon(false);
+            GameManager.Instance.AddBossStage(this);
+        }
     }
 
     public void ToggleMinimapIcon(bool toggle)
     {
         if(minimapIcon == null) return;
         minimapIcon.gameObject.SetActive(toggle);
+    }
+
+    public void ToggleBossUnlockIcon(bool toggle)
+    {
+        if(!bossRoom) return;
+        
+        if(toggle) anim.Play(hashedUnlockedAnim);
+        else anim.Play(hashedLockedAnim);
     }
 
 #region Spawning

--- a/_Manager Handler Scripts/GameManager.cs
+++ b/_Manager Handler Scripts/GameManager.cs
@@ -35,6 +35,7 @@ public class GameManager : MonoBehaviour
     public int totalTrialsCleared;
     public int totalTrialsNeeded = 2;
     [SerializeField] private List<DoorController> bossDoors;
+    [SerializeField] private EnemyStageManager bossStage;
 
     private void Awake()
     {
@@ -124,11 +125,18 @@ public class GameManager : MonoBehaviour
         {
             bossDoors[i].ToggleDoor(true);
             bossDoors[i].DisplayLockIcons(false);
+            //Animate icon when unlocked
+            bossStage.ToggleBossUnlockIcon(true);
         }
     }
 
     public void AddBossDoor(DoorController door)
     {
         bossDoors.Add(door);
+    }
+
+    public void AddBossStage(EnemyStageManager stage)
+    {
+        bossStage = stage;
     }
 }

--- a/_Manager Handler Scripts/Room Managers/CameraRoomManager.cs
+++ b/_Manager Handler Scripts/Room Managers/CameraRoomManager.cs
@@ -25,10 +25,11 @@ public class CameraRoomManager : MonoBehaviour
         if(roomClear == null) roomClear = GetComponentInParent<RoomClear>();
     }
 
-    // void Update()
-    // {
-    //     //may need to add another check to see if camera is in the correct room
-    // }
+    void Update()
+    {
+        //may need to add another check to see if camera is in the correct room
+        if(CameraAnchor == null) CameraAnchor = GameObject.FindGameObjectWithTag("CameraAnchor").transform;
+    }
 
     void OnTriggerEnter2D(Collider2D collision)
     {

--- a/_Menus/VideoSettingsManager.cs
+++ b/_Menus/VideoSettingsManager.cs
@@ -7,27 +7,47 @@ public class VideoSettingsManager : MonoBehaviour
 {
     public static VideoSettingsManager Instance { get; private set; }
 
-    public bool fullscreenEnabled;
+    [SerializeField] private bool fullscreenEnabledSaved;
 
     //Resolutions
     public int[] resWidth = { 960, 1280, 1920 };
     public int[] resHeight = { 540, 720, 1080 };
     // public TextMeshProUGUI resolutionDisplayed;
-    public int currentResIdx = 1; //TODO: TEMP, setting default to 720, should use savefile
+    [SerializeField] private int currentResIdxSaved = 1; //TODO: TEMP, setting default to 720, should use savefile
 
     private void Awake()
     {
-        Instance = this;
+        // Instance = this;
         // UpdateResDisplayed(currentResolution);
+
+        if(Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public void SaveFullscreen(bool fullscreen)
+    {
+        fullscreenEnabledSaved = fullscreen;
     }
 
     public void SaveResolution(int resIdx)
     {
-        currentResIdx = resIdx;
+        currentResIdxSaved = resIdx;
     }
     
-    public void SaveFullscreen(bool fullscreen)
+    public bool GetSavedFullscreen()
     {
-        fullscreenEnabled = fullscreen;
+        return fullscreenEnabledSaved;
+    }
+
+    public int GetSavedResIdx()
+    {
+        return currentResIdxSaved;
     }
 }

--- a/_Menus/VideoSettingsManager.cs
+++ b/_Menus/VideoSettingsManager.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+
+public class VideoSettingsManager : MonoBehaviour
+{
+    public static VideoSettingsManager Instance { get; private set; }
+
+    public bool fullscreenEnabled;
+
+    //Resolutions
+    public int[] resWidth = { 960, 1280, 1920 };
+    public int[] resHeight = { 540, 720, 1080 };
+    // public TextMeshProUGUI resolutionDisplayed;
+    public int currentResIdx = 1; //TODO: TEMP, setting default to 720, should use savefile
+
+    private void Awake()
+    {
+        Instance = this;
+        // UpdateResDisplayed(currentResolution);
+    }
+
+    public void SaveResolution(int resIdx)
+    {
+        currentResIdx = resIdx;
+    }
+    
+    public void SaveFullscreen(bool fullscreen)
+    {
+        fullscreenEnabled = fullscreen;
+    }
+}

--- a/_Menus/VideoSettingsManager.cs.meta
+++ b/_Menus/VideoSettingsManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0baef477fc132114fac8851058fb79eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Menus/VideoSettingsMenu.cs
+++ b/_Menus/VideoSettingsMenu.cs
@@ -6,53 +6,49 @@ using TMPro;
 
 public class VideoSettingsMenu : MonoBehaviour
 {
-    // public static VideoSettingsMenu Instance { get; private set; }
+    //DISPLAY ONLY
+    //  Used for Settings Menu, actual settings are saved in VideoSettingsManager.cs
 
 
     // //Resolutions
     public int[] resWidth = { 960, 1280, 1920 };
     public int[] resHeight = { 540, 720, 1080 };
     public TextMeshProUGUI resolutionDisplayed;
-    public int currentResolution = 1; //TODO: TEMP, setting default to 720, should use savefile
+    public int currentResIdx = 1; //TODO: TEMP, setting default to 720, should use savefile
     
     [Space(10)]
     public bool fullscreenEnabled;
 
     [Header("Toggle Buttons")]
     public GameObject fullscreenOnButton;
-    public GameObject fullscreenOffButton;
+    // public GameObject fullscreenOffButton;
 
     // //Temp Variables
     public int selectedResolution;
     public bool selectedFullscreen;
-
-    private void Start()
-    {
-        if(VideoSettingsManager.Instance != null)
-        {
-            currentResolution = VideoSettingsManager.Instance.currentResIdx;
-            fullscreenEnabled = VideoSettingsManager.Instance.fullscreenEnabled;
-        }
-
-        UpdateResDisplayed(currentResolution);
-        
-        fullscreenOnButton.SetActive(fullscreenEnabled);
-        fullscreenOffButton.SetActive(!fullscreenEnabled);
-
-        selectedResolution = currentResolution;
-        selectedFullscreen = fullscreenEnabled;
-    }
+    
 
     void OnEnable()
     {
-        Debug.Log("Current Res: " + Screen.currentResolution); //TODO: remove
+        //refresh displayed settings
+        if(VideoSettingsManager.Instance != null)
+        {
+            //Getting saved settings
+            currentResIdx = VideoSettingsManager.Instance.GetSavedResIdx();
+            fullscreenEnabled = VideoSettingsManager.Instance.GetSavedFullscreen();
+        }
+
+        //Update displayed settings with saved settings
+        selectedResolution = currentResIdx;
+        selectedFullscreen = fullscreenEnabled;
+
         UpdateSettings();
     }
 
     public void UpdateSettings() //called on initial Player scene load
     {
-        fullscreenOnButton.SetActive(fullscreenEnabled);
-        UpdateResDisplayed(currentResolution);
+        fullscreenOnButton.SetActive(selectedFullscreen);
+        UpdateResDisplayed(selectedResolution);
     }
 
     void UpdateResDisplayed(int selected)
@@ -76,26 +72,35 @@ public class VideoSettingsMenu : MonoBehaviour
         UpdateResDisplayed(selectedResolution);
     }
 
-    public void ApplyRes() //On Apply button press
+    public void ApplySettings() //On Apply button press
     {
-        SetRes(selectedResolution);
+        //Update settings to the selected
+        fullscreenEnabled = selectedFullscreen;
+        SetRes();
 
+        //Save settings
         if(VideoSettingsManager.Instance != null)
         {
-            VideoSettingsManager.Instance.SaveResolution(selectedResolution);
+            VideoSettingsManager.Instance.SaveResolution(currentResIdx);
             VideoSettingsManager.Instance.SaveFullscreen(fullscreenEnabled);
         }
     }
 
-    void SetRes(int selectRes)
+    void SetRes()
     {
-        Screen.SetResolution(resWidth[selectRes], resHeight[selectRes], selectedFullscreen, 60);
-        currentResolution = selectRes;
-        // fullscreenEnabled = selectedFullscreen; //TODO: testing, set elsewhere
+        FullScreenMode fullscreenMode;
+        if(fullscreenEnabled) fullscreenMode = FullScreenMode.FullScreenWindow;
+        else fullscreenMode = FullScreenMode.Windowed;
+
+        Screen.SetResolution(resWidth[selectedResolution], resHeight[selectedResolution],
+        fullscreenMode, new RefreshRate(){numerator = 60, denominator = 1});
+
+        currentResIdx = selectedResolution;
     }
 
     public void ToggleFullscreenButton()
     {
+        //Called when button is pressed, will display the opposite of the previous selection
         if (selectedFullscreen)
         {
             selectedFullscreen = false;
@@ -106,6 +111,5 @@ public class VideoSettingsMenu : MonoBehaviour
         }
 
         fullscreenOnButton.SetActive(selectedFullscreen);
-        fullscreenOffButton.SetActive(!selectedFullscreen);
     }
 }

--- a/_Menus/VideoSettingsMenu.cs
+++ b/_Menus/VideoSettingsMenu.cs
@@ -6,44 +6,52 @@ using TMPro;
 
 public class VideoSettingsMenu : MonoBehaviour
 {
-    public static VideoSettingsMenu Instance { get; private set; }
+    // public static VideoSettingsMenu Instance { get; private set; }
 
-    public bool fullscreenExclusive = false;
 
-    //Resolutions
+    // //Resolutions
     public int[] resWidth = { 960, 1280, 1920 };
     public int[] resHeight = { 540, 720, 1080 };
     public TextMeshProUGUI resolutionDisplayed;
     public int currentResolution = 1; //TODO: TEMP, setting default to 720, should use savefile
+    
+    [Space(10)]
+    public bool fullscreenEnabled;
 
-    //Toggle Buttons
+    [Header("Toggle Buttons")]
     public GameObject fullscreenOnButton;
     public GameObject fullscreenOffButton;
 
-    //Temp Variables
+    // //Temp Variables
     public int selectedResolution;
     public bool selectedFullscreen;
 
-    private void Awake()
+    private void Start()
     {
-        Instance = this;
+        if(VideoSettingsManager.Instance != null)
+        {
+            currentResolution = VideoSettingsManager.Instance.currentResIdx;
+            fullscreenEnabled = VideoSettingsManager.Instance.fullscreenEnabled;
+        }
+
         UpdateResDisplayed(currentResolution);
         
-        fullscreenOnButton.SetActive(fullscreenExclusive);
-        fullscreenOffButton.SetActive(!fullscreenExclusive);
+        fullscreenOnButton.SetActive(fullscreenEnabled);
+        fullscreenOffButton.SetActive(!fullscreenEnabled);
 
         selectedResolution = currentResolution;
-        selectedFullscreen = fullscreenExclusive;
+        selectedFullscreen = fullscreenEnabled;
     }
 
     void OnEnable()
     {
+        Debug.Log("Current Res: " + Screen.currentResolution); //TODO: remove
         UpdateSettings();
     }
 
     public void UpdateSettings() //called on initial Player scene load
     {
-        fullscreenOnButton.SetActive(fullscreenExclusive);
+        fullscreenOnButton.SetActive(fullscreenEnabled);
         UpdateResDisplayed(currentResolution);
     }
 
@@ -71,13 +79,19 @@ public class VideoSettingsMenu : MonoBehaviour
     public void ApplyRes() //On Apply button press
     {
         SetRes(selectedResolution);
+
+        if(VideoSettingsManager.Instance != null)
+        {
+            VideoSettingsManager.Instance.SaveResolution(selectedResolution);
+            VideoSettingsManager.Instance.SaveFullscreen(fullscreenEnabled);
+        }
     }
 
     void SetRes(int selectRes)
     {
         Screen.SetResolution(resWidth[selectRes], resHeight[selectRes], selectedFullscreen, 60);
         currentResolution = selectRes;
-        fullscreenExclusive = selectedFullscreen;
+        // fullscreenEnabled = selectedFullscreen; //TODO: testing, set elsewhere
     }
 
     public void ToggleFullscreenButton()

--- a/_UI Scripts/ButtonSelect.cs
+++ b/_UI Scripts/ButtonSelect.cs
@@ -5,15 +5,19 @@ using UnityEngine.UI;
 
 public class ButtonSelect : MonoBehaviour
 {
+    [Header("Default button for Keyboard navigation")]
+    public bool enable = false;
     public Button primaryButton;
 
     void Start()
     {
+        if(!enable) return;
         primaryButton.Select();
     }
 
     private void OnEnable()
     {
+        if(!enable) return;
         primaryButton.Select(); //workaround with multiple menus being toggled
     }
 }

--- a/_UI Scripts/MainMenu.cs
+++ b/_UI Scripts/MainMenu.cs
@@ -11,13 +11,25 @@ public class MainMenu : MonoBehaviour
     public SettingsMenu settingsMenu;
     public GameObject gameSettings;
     public GameObject videoSettings;
+    public GameObject soundSettings;
 
     public GameObject creditsMenuUI;
+    [SerializeField] string[] StartingScenes;
     
-    public void PlayDemo()
+    public void Play()
     {
         mainMenuUI.SetActive(false);
-        AsyncLevelLoader.asyncLevelLoader.StartGame("_Demo_Stage", "MainMenu");
+
+        if(StartingScenes.Length > 1)
+        {
+            int randIdx = Random.Range(0, StartingScenes.Length);
+            AsyncLevelLoader.asyncLevelLoader.StartGame(StartingScenes[randIdx], "MainMenu");
+        }
+        else
+        {
+            AsyncLevelLoader.asyncLevelLoader.StartGame(StartingScenes[0], "MainMenu");
+        }
+
     }
 
     /*public void Play()
@@ -55,6 +67,13 @@ public class MainMenu : MonoBehaviour
         settingsMenuObj.SetActive(true);
         videoSettings.SetActive(false);
         gameSettings.SetActive(false);
+        soundSettings.SetActive(false);
+    }
+
+    public void SettingsToSoundSettings()
+    {
+        settingsMenuObj.SetActive(false);
+        soundSettings.SetActive(true);
     }
 //
 

--- a/_UI Scripts/MainMenu.cs
+++ b/_UI Scripts/MainMenu.cs
@@ -15,7 +15,7 @@ public class MainMenu : MonoBehaviour
 
     public GameObject creditsMenuUI;
     [SerializeField] string[] StartingScenes;
-    
+
     public void Play()
     {
         mainMenuUI.SetActive(false);
@@ -29,7 +29,6 @@ public class MainMenu : MonoBehaviour
         {
             AsyncLevelLoader.asyncLevelLoader.StartGame(StartingScenes[0], "MainMenu");
         }
-
     }
 
     /*public void Play()

--- a/_UI Scripts/PauseMenu.cs
+++ b/_UI Scripts/PauseMenu.cs
@@ -7,7 +7,7 @@ public class PauseMenu : MonoBehaviour
 {
     public static bool GameIsPaused = false;
 
-    [SerializeField] string currentStage;
+    [SerializeField] string currentStage = "Tileset1_LevelGen";
 
     public GameObject pauseMenuUI;
     public GameObject settingsMenuUI;
@@ -74,8 +74,6 @@ public class PauseMenu : MonoBehaviour
 
     public void RestartLevel() //For use with Demo level only //TODO: remove once stages are added
     {
-        //TODO: needs more testing
-
         //Load TutorialStage or FirstStage instead, Restart Run
         AsyncLevelLoader.asyncLevelLoader.StartGame("Tileset1_LevelGen", currentStage);
         //!TODO: doesn't work 
@@ -89,7 +87,15 @@ public class PauseMenu : MonoBehaviour
     {
         Time.timeScale = 1f;
         GameIsPaused = false;
-        SceneManager.LoadScene("MainMenu");
+        
+        // SceneManager.LoadScene("MainMenu"); //TODO; replace 
+
+        
+
+        //TODO: use this instead
+        AsyncLevelLoader.asyncLevelLoader.LoadMainMenu("Tileset1_LevelGen");
+
+
         //SceneManager.LoadScene(0);
     }
 


### PR DESCRIPTION
### Scenes
- MainMenu scene added
- AsyncSceneLoader updated with loading screen
  - Loading screen added
  - Music volume fade added when loading to a new scene
- _NeverUnload scene added, objects stay persistent across loaded scenes
  - Moved AudioManager to _NeverUnload to launch with MainMenu
  - Video Settings moved to _NeverUnload

### Settings Menus
- Screenshake toggle saved across screens
- Audio Slider in setting will update to current audio settings when loaded

### Minimap
- Boss Icon is now static when locked, animated when unlocked

### Misc
- Moved background light overlay to Camera object parent