### PR TITLE
Boss Music, Audio transitions, Archer fix

### DIFF
--- a/_Audio/AudioManager.cs
+++ b/_Audio/AudioManager.cs
@@ -11,6 +11,7 @@ public class AudioManager : MonoBehaviour
     [Header("Audio Settings")]
     [SerializeField] public bool toggleSFX;
     [SerializeField] public bool toggleMusic;
+    [SerializeField] public PlayMusic playMusic;
     [Header("Audio Sources")]
     [SerializeField] public AudioSource musicSource, ambientSource, generalSfxSource;
 
@@ -38,7 +39,7 @@ public class AudioManager : MonoBehaviour
 
     [Space(20)]
     [Header("Audio Fade Settings")]
-    [SerializeField] float fadeDuration = 2f;
+    [SerializeField] public float fadeDuration = 2f;
 
     [Header("Debugging")]
     [SerializeField] private float startVolumeMusic;

--- a/_Audio/PlayMusic.cs
+++ b/_Audio/PlayMusic.cs
@@ -1,0 +1,135 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+public class PlayMusic : MonoBehaviour
+{
+    [Header("References")]
+    [SerializeField] AudioSource musicAudioSource;
+    [SerializeField] AudioManager audioManager;
+    [SerializeField] float fadeDuration;
+
+    [Space(20)]
+
+    [SerializeField] AudioClip MenuMusic;
+    [SerializeField] AudioClip[] GameMusic;
+    [SerializeField] AudioClip[] BossMusicIntro;
+    [SerializeField] AudioClip[] BossMusicLoop;
+    Coroutine TransitionCoroutine;
+
+    void Start()
+    {
+        if(audioManager == null) audioManager = AudioManager.Instance;
+        fadeDuration = audioManager.fadeDuration;
+        if(audioManager.playMusic == null) audioManager.playMusic = this;
+
+        AudioIngameSetup();
+    }
+
+    // //DEBUGGING
+    // void Update()
+    // {
+    //     if(Input.GetKeyDown(KeyCode.Q))
+    //     {
+    //         PlayBossMusic();
+    //     }
+    // }
+
+    public void AudioIngameSetup()
+    {
+        //prevents audio cut when transitioning from intro to loop
+        StartCoroutine(TransitionSetup());
+    }
+
+    IEnumerator TransitionSetup()
+    {
+        //Swap audio clips, prevents transition clipping
+        audioManager.musicSource.mute = true;
+        SwapClip(BossMusicIntro[0]);
+        yield return new WaitForSeconds(.5f);
+        SwapClip(BossMusicLoop[0]);
+        yield return new WaitForSeconds(.5f);
+
+        audioManager.FadeOutAudio();
+        SwapClip(MenuMusic);
+        yield return new WaitForSeconds(fadeDuration);
+        audioManager.musicSource.mute = false;
+        audioManager.FadeInAudio();
+    }
+
+
+    private void SwapMusic(AudioClip newMusic)
+    {
+        StartCoroutine(TransitionMusic(newMusic));
+    }
+
+    IEnumerator TransitionMusic(AudioClip newMusic)
+    {
+        audioManager.FadeOutAudio();
+
+        yield return new WaitForSeconds(fadeDuration);
+
+        musicAudioSource.loop = true;
+        SwapClip(newMusic);
+
+        audioManager.FadeInAudio();
+    }
+
+    private void SwapClip(AudioClip newMusic)
+    {
+        musicAudioSource.clip = newMusic;
+        musicAudioSource.Play();
+    }
+
+
+#region Boss Music: Intro -> Loop
+    private void SwapIntroLoopMusic(AudioClip bossMusic)
+    {
+        TransitionCoroutine = StartCoroutine(TransitionMusic_IntroLoop(bossMusic));
+    }
+
+    IEnumerator TransitionMusic_IntroLoop(AudioClip newMusic)
+    {
+        audioManager.FadeOutAudio();
+
+        yield return new WaitForSecondsRealtime(fadeDuration);
+
+        // musicAudioSource.loop = true;
+        SwapClip(newMusic);
+
+        audioManager.FadeInAudio();
+        // Invoke("StartBossMusicLoop", BossMusicIntro[0].length); //.length not returning correct value
+        yield return new WaitForSecondsRealtime(17.145f);
+        StartBossMusicLoop();
+    }
+#endregion
+
+    public void PlayBossMusic()
+    {
+        SwapIntroLoopMusic(BossMusicIntro[0]);
+        // Invoke("StartBossMusicLoop", BossMusicIntro[0].length);
+    }
+
+    private void StartBossMusicLoop()
+    {
+        SwapClip(BossMusicLoop[0]);
+    }
+
+    public void PlayMenuMusic()
+    {
+        SwapClip(MenuMusic);
+    }
+
+    public void PlayInGameMusic()
+    {
+        SwapClip(MenuMusic); //TODO: MenuMusic placeholder until separate InGame music
+    }
+
+    public void TransitionBossMusicToNormal()
+    {
+        SwapMusic(MenuMusic);
+        if(TransitionCoroutine != null) StopCoroutine(TransitionCoroutine);
+    }
+    
+}

--- a/_Audio/PlayMusic.cs.meta
+++ b/_Audio/PlayMusic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc33804178bc3774297bf5d05d76ad41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs
+++ b/_Augments/Alternate Shops/AugmentDisplay_HealOnly.cs
@@ -34,6 +34,11 @@ public class AugmentDisplay_HealOnly : AugmentDisplay
             }
         }
 
+        if(Price > GameManager.Instance.Inventory.goldAmount)
+            UpdateColor(false);
+        else
+            UpdateColor(true);
+
         // GetBorderColor();
         Border_Image.color = Color.green;
     }

--- a/_Enemy Scripts/Base_BossCombat.cs
+++ b/_Enemy Scripts/Base_BossCombat.cs
@@ -182,6 +182,7 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
 
     public virtual void StartSpawn() //Manual call on 
     {
+        AudioManager.Instance.playMusic.PlayBossMusic();
         StartCoroutine(SpawnCO(spawnDelay));
     }
 
@@ -547,6 +548,8 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         healthBar.gameObject.SetActive(false);
         canAttack = false;
         isAlive = false;
+
+        AudioManager.Instance.playMusic.TransitionBossMusicToNormal();
 
         //Attack Coroutine checks
         StopAttack();

--- a/_Enemy Scripts/Base_EnemyController.cs
+++ b/_Enemy Scripts/Base_EnemyController.cs
@@ -115,7 +115,7 @@ public class Base_EnemyController : MonoBehaviour
     protected virtual void ChasePlayer()
     {
         if(combat.isAttacking) return;
-        
+
         if (!isRangedAttack)
         {
             if (!combat.chasePlayer) return;
@@ -124,7 +124,7 @@ public class Base_EnemyController : MonoBehaviour
             if (raycast.wallDetect || !raycast.ledgeDetect) return; //May not be needed with platform check
         }
         
-        // if (raycast.playerDetectFront || raycast.playerDetectBack) //-
+        //Range units can still aggro towards the Player if on different platforms
         if (playerDetected)
         {
             // combat.instantiateManager.TextPopups.ShowIndicator(combat.hitEffectsOffset.position);

--- a/_Enemy Scripts/Base_EnemyController.cs
+++ b/_Enemy Scripts/Base_EnemyController.cs
@@ -114,6 +114,8 @@ public class Base_EnemyController : MonoBehaviour
 
     protected virtual void ChasePlayer()
     {
+        if(combat.isAttacking) return;
+        
         if (!isRangedAttack)
         {
             if (!combat.chasePlayer) return;

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -646,6 +646,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
     {
         healthBar.gameObject.SetActive(false);
         isAlive = false;
+        AudioManager.Instance.playMusic.TransitionBossMusicToNormal();
 
         //Attack Coroutine checks
         if(AttackingCO != null) StopCoroutine(AttackingCO);

--- a/_Enemy Scripts/Tier 2 Enemies/Archer_EnemyController.cs
+++ b/_Enemy Scripts/Tier 2 Enemies/Archer_EnemyController.cs
@@ -23,15 +23,12 @@ public class Archer_EnemyController : Base_EnemyController
 
     protected override void AttackCheckClose()
     {
-        // return; //TODO: TESTING //=========1
         if(combat.altAttacking) return; //Check if attack is already started, this prevents Manualflip being called during attack coroutine
-        // if (!PlatformCheck() || isRangedAttack) return; //========1
         if (!PlatformCheck() && !isRangedAttack) return;
 
         if (raycast.playerInRangeClose)
         {
             PlayerDistCheck();
-            // combat.altAttacking = true;
             StartCoroutine(LungeAttack());
         }
     }
@@ -44,8 +41,7 @@ public class Archer_EnemyController : Base_EnemyController
 
         if (raycast.playerInRangeFar && combat.CanAttackFar())
         {
-            // PlayerDistCheck(); //------------------2 , trying to add, should dash from player 
-            // combat.altAttacking = true;
+            PlayerDistCheck();
             StartCoroutine(LungeAttack());
         }
     }
@@ -65,18 +61,25 @@ public class Archer_EnemyController : Base_EnemyController
         combat.chasePlayer = false;
         combat.isAttacking = true;
         combat.ToggleHealthbar(false);
-        combat.ToggleDamageImmune(true);
+
         yield return new WaitForSeconds(0.1f);
+
+        bool playerInfront = raycast.playerDetectedToRight;
+        if(!raycast.backToLedge) playerInfront = false;
+        // playerDetected = false;
+        
         combat.animator.PlayManualAnim(1, 0.75f); //Vanish
+        combat.ToggleDamageImmune(true);
+
         yield return new WaitForSeconds(0.2f);
+        combat.ToggleDamageImmune(false);
         movement.canMove = false;
 
         //Lunge then flip towards the Player and start Attack
-        if(PlayerDistCheck() <= raycast.attackRangeClose) LungeCheck(9);
-        else LungeCheck(0);
+        if(PlayerDistCheck() <= raycast.attackRangeClose) LungeCheck(playerInfront, 9);
+        else LungeCheck(playerInfront, 0);
 
         yield return new WaitForSeconds(0.55f);
-        combat.ToggleDamageImmune(false);
         combat.ToggleHealthbar(true);
         // yield return new WaitForSeconds(.35f);
         
@@ -87,25 +90,25 @@ public class Archer_EnemyController : Base_EnemyController
         combat.AttackFar();
     }
 
-    public void LungeCheck(float lungeStrength = 4f, float duration = .3f)
+    public void LungeCheck(bool playerInfront, float lungeStrength = 4f, float duration = .3f)
     {
         // movement.ToggleFlip(false);
-        
+
         if(raycast.playerInRangeClose) //Player too close
         {
             if(raycast.backToWall || !raycast.backToLedge)
             {
                 //Lunge forwards
-                combat.Lunge(!raycast.playerDetectedToRight, lungeStrength, duration);
+                combat.Lunge(!playerInfront, lungeStrength, duration);
             }
             else
             {
                 //Lunge backwards
-                combat.Lunge(raycast.playerDetectedToRight, lungeStrength, duration);
+                combat.Lunge(playerInfront, lungeStrength, duration);
             }
         }else
         {
-            combat.Lunge(!raycast.playerDetectedToRight, lungeStrength, duration);
+            combat.Lunge(!playerInfront, lungeStrength, duration);
         }
     }
 

--- a/_Level Generator/LevelBuilder.cs
+++ b/_Level Generator/LevelBuilder.cs
@@ -59,7 +59,7 @@ public class LevelBuilder : MonoBehaviour
 
     //Player and Camera transforms
     private Transform player;
-    private Vector3 playerStartingPos;
+    [SerializeField] private Vector3 playerStartingPos;
     private CameraRoomManager cameraManager;
 
     private void Start()
@@ -67,13 +67,18 @@ public class LevelBuilder : MonoBehaviour
         WallGen = GetComponent<WallGenerator>();
         RoomGen = GetComponent<RoomGenerator>();
         GeneratedOrigins = new GameObject[totalRooms];
-        player = GameObject.FindGameObjectWithTag("Player").transform;
-        playerStartingPos = player.position;
+        // player = GameObject.FindGameObjectWithTag("Player").transform;
+        player = GameManager.Instance.playerTransform;
+        // playerStartingPos = player.position;
         cameraManager = GameObject.FindGameObjectWithTag("GameManager").GetComponentInChildren<CameraRoomManager>();
+
+        DeleteOrigins();
+        GameManager.Instance.RestartLevelCount();
     }
 
     void Update()
     {
+        #if UNITY_EDITOR
         if (DEBUGGING)
         {
             if (!builderRunning)
@@ -83,6 +88,7 @@ public class LevelBuilder : MonoBehaviour
                     GameManager.Instance.RestartLevelCount();
                 }
         }
+        #endif
 
         if (WallGen.wallGenDone && !builderRunning) return; //Stop updating raycasts if not needed
         OriginConnectCheck(); //Raycasts
@@ -126,6 +132,9 @@ public class LevelBuilder : MonoBehaviour
         while (!RoomGen.roomGenDone) yield return null;
 
         Time.timeScale = 1;
+        player.position = playerStartingPos;
+
+        AsyncLevelLoader.asyncLevelLoader.allowLoad = true;
     }
 
     IEnumerator GenerateOriginsCO()

--- a/_Level_Scene_Load/AsyncLevelLoader.cs
+++ b/_Level_Scene_Load/AsyncLevelLoader.cs
@@ -84,8 +84,8 @@ public class AsyncLevelLoader : MonoBehaviour
             yield return null;
         }
 
-        // LoadingText.SetActive(false);
-        AudioManager.Instance.FadeInAudio();
+        AudioManager.Instance.playMusic.AudioIngameSetup();
+        // AudioManager.Instance.FadeInAudio();
         GameManager.Instance.TogglePlayerInput(true);
 
         StartGame("Tileset1_LevelGen", "MainMenu");
@@ -282,6 +282,7 @@ public class AsyncLevelLoader : MonoBehaviour
         // SceneManager.LoadScene("MainMenu");
 
         // LoadingText.SetActive(false); //toggled in EndLoadingCO
+        AudioManager.Instance.playMusic.PlayMenuMusic();
         AudioManager.Instance.FadeInAudio();
 
         yield return EndLoadingCO();

--- a/_Level_Scene_Load/AsyncLevelLoader.cs
+++ b/_Level_Scene_Load/AsyncLevelLoader.cs
@@ -16,6 +16,7 @@ public class AsyncLevelLoader : MonoBehaviour
     [SerializeField] private float loadScreenFadeOutDuration;
     [SerializeField] private string loadingEndAnim = "LoadingFadeEnd";
     [SerializeField] private float loadScreenFadeInDuration;
+    public bool allowLoad;
     
 
     [Space(10)]
@@ -83,7 +84,7 @@ public class AsyncLevelLoader : MonoBehaviour
             yield return null;
         }
 
-        LoadingText.SetActive(false);
+        // LoadingText.SetActive(false);
         AudioManager.Instance.FadeInAudio();
         GameManager.Instance.TogglePlayerInput(true);
 
@@ -225,6 +226,7 @@ public class AsyncLevelLoader : MonoBehaviour
         LoadingText.SetActive(true);
 
         LoadPlayer();
+        allowLoad = false;
 
         while (!playerLoaded)
         {
@@ -236,11 +238,19 @@ public class AsyncLevelLoader : MonoBehaviour
 
         SceneManager.UnloadSceneAsync(unloadStage); //Unload MainMenu
         LoadScene(startStage);
+        // allowLoad = true;
+
+        while(!allowLoad)
+        {
+            //allowLoad set to true once level generation is done
+            Debug.Log("Building Level...");
+            yield return null;
+        }
 
         yield return EndLoadingCO();
-        LoadingText.SetActive(false);
+        // LoadingText.SetActive(false);
 
-        GameManager.Instance.TogglePlayerInput(true);
+        // GameManager.Instance.TogglePlayerInput(true);
         AudioManager.Instance.FadeInAudio();
     }
 
@@ -271,11 +281,11 @@ public class AsyncLevelLoader : MonoBehaviour
 
         // SceneManager.LoadScene("MainMenu");
 
-        LoadingText.SetActive(false);
+        // LoadingText.SetActive(false); //toggled in EndLoadingCO
         AudioManager.Instance.FadeInAudio();
-        GameManager.Instance.TogglePlayerInput(true);
 
         yield return EndLoadingCO();
+        GameManager.Instance.TogglePlayerInput(true);
         // yield return new WaitForSecondsRealtime(loadScreenFadeOutDuration);
     }
 
@@ -288,6 +298,7 @@ public class AsyncLevelLoader : MonoBehaviour
     IEnumerator StartLoadingCO()
     {
         LoadScreenAnim.Play(loadingStartAnim);
+        LoadingText.SetActive(true);
         yield return new WaitForSecondsRealtime(loadScreenFadeOutDuration);
     }
 
@@ -298,7 +309,10 @@ public class AsyncLevelLoader : MonoBehaviour
 
     IEnumerator EndLoadingCO()
     {
+        // yield return new WaitForSecondsRealtime(1.5f);
         LoadScreenAnim.Play(loadingEndAnim);
+        LoadingText.SetActive(false);
+        GameManager.Instance.TogglePlayerInput(true);
         yield return new WaitForSecondsRealtime(loadScreenFadeInDuration);
     }
 }

--- a/_UI Scripts/MenuEventSystemSwap.cs
+++ b/_UI Scripts/MenuEventSystemSwap.cs
@@ -5,6 +5,11 @@ using UnityEngine.UI;
 
 public class MenuEventSystemSwap : MonoBehaviour
 {
+    //! - Use ButtonSelect.cs instead
+
+
+
+
     //The start Selected button enabled Keyboard menu navigation
     [SerializeField] Button startSelectedButton;
 


### PR DESCRIPTION
### Music/Audio
- Boss Music added
- Added transition function for music tracks with an Intro and Loop clip
- Ambient music plays after loading the Main Menu
- Music transitions back to normal after the Boss dies or when the run is reset

### Scene Loading
- Loading screen now waits for level to finish building before ending load screen

### Enemies
- Shortened Archer damage immune duration

### Bug Fixes
- Fixed "Loading..." text disappearing too soon
- Fixed visual clipping issues with Trial Room 2
- Fixed Enemy controller script causing Archer to chase Player while attacking
  - Enemies with a ranged attack will now ignore ChasePlayer function while attacking
- Fixed Heal Kit item not updating price text color when the Player can't afford it