### PR TITLE
Updated Music/Audio handler, Augment proc chance

### DIFF
--- a/_Audio/AudioManager.cs
+++ b/_Audio/AudioManager.cs
@@ -13,7 +13,7 @@ public class AudioManager : MonoBehaviour
     [SerializeField] public bool toggleMusic;
     [SerializeField] public PlayMusic playMusic;
     [Header("Audio Sources")]
-    [SerializeField] public AudioSource musicSource, ambientSource, generalSfxSource;
+    [SerializeField] public AudioSource musicSource, musicSource2, ambientSource, generalSfxSource;
 
     [Space(10)]
     [Header("Player SFX")]
@@ -71,6 +71,7 @@ public class AudioManager : MonoBehaviour
     void Start()
     {
         startVolumeMusic = musicSource.volume;
+        musicSource2.volume = musicSource.volume;
         startVolumeAmbient = ambientSource.volume;
 
         startingSetVolumeMusic = startVolumeMusic;
@@ -94,11 +95,13 @@ public class AudioManager : MonoBehaviour
             if (fadeTimer < fadeDuration)
             {
                 musicSource.volume = Mathf.Lerp(startVolumeMusic, targetVolume, fadeTimer / fadeDuration);
+                musicSource2.volume = Mathf.Lerp(startVolumeMusic, targetVolume, fadeTimer / fadeDuration);
                 fadeTimer += Time.unscaledDeltaTime;
             }
             else
             {
                 musicSource.volume = targetVolume;
+                musicSource2.volume = targetVolume;
                 fadingAudio = false;
                 fadeTimer = 0f;
             }
@@ -187,6 +190,7 @@ public class AudioManager : MonoBehaviour
     public void ChangeMusicVolume(float value)
     {
         musicSource.volume = value;
+        musicSource2.volume = value;
         startingSetVolumeMusic = value;
         // SettingsManager.Instance.musicVolume = value;
     }
@@ -228,11 +232,11 @@ public class AudioManager : MonoBehaviour
     public void ToggleMusic(bool toggle)
     {
         musicSource.mute = toggle;
+        musicSource2.mute = toggle;
     }
 
     public void FadeOutAudio()
     {
-        // musicSource.
         // ambientSource
         if(!fadingAudio)
         {

--- a/_Audio/PlayMusic.cs
+++ b/_Audio/PlayMusic.cs
@@ -11,10 +11,25 @@ public class PlayMusic : MonoBehaviour
     [SerializeField] float fadeDuration;
 
     [Space(20)]
-
     [SerializeField] AudioClip MenuMusic;
-    [SerializeField] AudioClip[] GameMusic;
+
+    [Space(20)]
+    [Header("- Music Manager Variables -")]
+    //https://www.youtube.com/watch?v=3yKcrig3bU0
+    [SerializeField] double musicDuration; //1 name
+    [SerializeField] double goalTime; //1 name
+    [SerializeField] AudioClip currentClip;
+
+    [Space(20)]
+    [Header("- Stage Music -")]
+    [SerializeField] AudioClip[] StageMusicIntro;
+    [SerializeField] float[] StageMusicIntroLength;
+    [SerializeField] AudioClip[] StageMusicLoop;
+
+    [Space(10)]
+    [Header("- Boss Music -")]
     [SerializeField] AudioClip[] BossMusicIntro;
+    [SerializeField] float[] BossMusicIntroLength;
     [SerializeField] AudioClip[] BossMusicLoop;
     Coroutine TransitionCoroutine;
 
@@ -24,7 +39,34 @@ public class PlayMusic : MonoBehaviour
         fadeDuration = audioManager.fadeDuration;
         if(audioManager.playMusic == null) audioManager.playMusic = this;
 
-        AudioIngameSetup();
+        // AudioIngameSetup(); //TODO: NOT NEEDED IF FIX WORKS
+
+
+    }
+
+    void Update()
+    {
+        //1
+        if(AudioSettings.dspTime > goalTime - 1) //1 what is '1'?
+        {
+            PlayScheduledClip();
+        }
+    }
+
+    void PlayScheduledClip() //1
+    {
+        musicAudioSource.clip = currentClip;
+        musicAudioSource.PlayScheduled(goalTime);
+
+        musicDuration = (double)currentClip.samples / currentClip.frequency;
+        goalTime = goalTime + musicDuration;
+
+        // audioToggle = 1 - audioToggle; //??? is probably just index? of next clip
+    }
+
+    void SetCurrentClip(AudioClip clip) //1
+    {
+        currentClip = clip;
     }
 
     // //DEBUGGING
@@ -36,23 +78,30 @@ public class PlayMusic : MonoBehaviour
     //     }
     // }
 
-    public void AudioIngameSetup()
+    public void AudioIngameSetup(bool menuStart = true)
     {
         //prevents audio cut when transitioning from intro to loop
-        StartCoroutine(TransitionSetup());
+        // StartCoroutine(TransitionSetup(menuStart));
+
+        //TODO: NOT NEEDED IF FIX WORKS
     }
 
-    IEnumerator TransitionSetup()
+    IEnumerator TransitionSetup(bool playMenuMusic)
     {
         //Swap audio clips, prevents transition clipping
         audioManager.musicSource.mute = true;
         SwapClip(BossMusicIntro[0]);
-        yield return new WaitForSeconds(.5f);
+        yield return new WaitForSeconds(.3f);
         SwapClip(BossMusicLoop[0]);
-        yield return new WaitForSeconds(.5f);
+        yield return new WaitForSeconds(.3f);
+        SwapClip(StageMusicLoop[0]);
+        yield return new WaitForSeconds(.3f);
 
         audioManager.FadeOutAudio();
-        SwapClip(MenuMusic);
+        
+        if(playMenuMusic) SwapClip(MenuMusic);
+        else PlayStageMusic();
+
         yield return new WaitForSeconds(fadeDuration);
         audioManager.musicSource.mute = false;
         audioManager.FadeInAudio();
@@ -84,30 +133,33 @@ public class PlayMusic : MonoBehaviour
 
 
 #region Boss Music: Intro -> Loop
-    private void SwapIntroLoopMusic(AudioClip bossMusic)
+    private void SwapIntroLoopMusic(AudioClip introClip, float introLength, AudioClip loopClip)
     {
-        TransitionCoroutine = StartCoroutine(TransitionMusic_IntroLoop(bossMusic));
+        TransitionCoroutine = StartCoroutine(TransitionMusic_IntroLoop(introClip, introLength, loopClip));
     }
 
-    IEnumerator TransitionMusic_IntroLoop(AudioClip newMusic)
+    IEnumerator TransitionMusic_IntroLoop(AudioClip newMusic, float introLength, AudioClip loopClip)
     {
         audioManager.FadeOutAudio();
 
-        yield return new WaitForSecondsRealtime(fadeDuration);
+        yield return new WaitForSeconds(fadeDuration);
 
         // musicAudioSource.loop = true;
         SwapClip(newMusic);
 
         audioManager.FadeInAudio();
         // Invoke("StartBossMusicLoop", BossMusicIntro[0].length); //.length not returning correct value
-        yield return new WaitForSecondsRealtime(17.145f);
-        StartBossMusicLoop();
+        // yield return new WaitForSecondsRealtime(17.145f);
+        // yield return new WaitForSecondsRealtime(BossMusicIntroLength[index]);
+        yield return new WaitForSeconds(introLength);
+        // StartBossMusicLoop();
+        SwapClip(loopClip);
     }
 #endregion
 
     public void PlayBossMusic()
     {
-        SwapIntroLoopMusic(BossMusicIntro[0]);
+        SwapIntroLoopMusic(BossMusicIntro[0], BossMusicIntroLength[0], BossMusicLoop[0]);
         // Invoke("StartBossMusicLoop", BossMusicIntro[0].length);
     }
 
@@ -121,14 +173,17 @@ public class PlayMusic : MonoBehaviour
         SwapClip(MenuMusic);
     }
 
-    public void PlayInGameMusic()
+    public void PlayStageMusic()
     {
-        SwapClip(MenuMusic); //TODO: MenuMusic placeholder until separate InGame music
+        // SwapClip(MenuMusic); //TODO: MenuMusic placeholder until separate InGame music
+        // SwapClip(GameMusicIntro[0]);
+        SwapIntroLoopMusic(StageMusicIntro[0], StageMusicIntroLength[0], StageMusicLoop[0]);
     }
 
     public void TransitionBossMusicToNormal()
     {
-        SwapMusic(MenuMusic);
+        SwapMusic(StageMusicLoop[0]);
+        // PlayStageMusic();
         if(TransitionCoroutine != null) StopCoroutine(TransitionCoroutine);
     }
     

--- a/_Audio/PlayMusic.cs
+++ b/_Audio/PlayMusic.cs
@@ -7,6 +7,7 @@ public class PlayMusic : MonoBehaviour
 {
     [Header("References")]
     [SerializeField] AudioSource musicAudioSource;
+    [SerializeField] AudioSource musicIntroAudioSource;
     [SerializeField] AudioManager audioManager;
     [SerializeField] float fadeDuration;
 
@@ -15,10 +16,8 @@ public class PlayMusic : MonoBehaviour
 
     [Space(20)]
     [Header("- Music Manager Variables -")]
-    //https://www.youtube.com/watch?v=3yKcrig3bU0
     [SerializeField] double musicDuration; //1 name
-    [SerializeField] double goalTime; //1 name
-    [SerializeField] AudioClip currentClip;
+    [SerializeField] double scheduledTime; //1 name
 
     [Space(20)]
     [Header("- Stage Music -")]
@@ -39,78 +38,13 @@ public class PlayMusic : MonoBehaviour
         fadeDuration = audioManager.fadeDuration;
         if(audioManager.playMusic == null) audioManager.playMusic = this;
 
-        // AudioIngameSetup(); //TODO: NOT NEEDED IF FIX WORKS
-
-
+        SwapMusic(MenuMusic);
     }
 
-    void Update()
+    private void SwapMusic(AudioClip newMusic, bool looping = false)
     {
-        //1
-        if(AudioSettings.dspTime > goalTime - 1) //1 what is '1'?
-        {
-            PlayScheduledClip();
-        }
-    }
-
-    void PlayScheduledClip() //1
-    {
-        musicAudioSource.clip = currentClip;
-        musicAudioSource.PlayScheduled(goalTime);
-
-        musicDuration = (double)currentClip.samples / currentClip.frequency;
-        goalTime = goalTime + musicDuration;
-
-        // audioToggle = 1 - audioToggle; //??? is probably just index? of next clip
-    }
-
-    void SetCurrentClip(AudioClip clip) //1
-    {
-        currentClip = clip;
-    }
-
-    // //DEBUGGING
-    // void Update()
-    // {
-    //     if(Input.GetKeyDown(KeyCode.Q))
-    //     {
-    //         PlayBossMusic();
-    //     }
-    // }
-
-    public void AudioIngameSetup(bool menuStart = true)
-    {
-        //prevents audio cut when transitioning from intro to loop
-        // StartCoroutine(TransitionSetup(menuStart));
-
-        //TODO: NOT NEEDED IF FIX WORKS
-    }
-
-    IEnumerator TransitionSetup(bool playMenuMusic)
-    {
-        //Swap audio clips, prevents transition clipping
-        audioManager.musicSource.mute = true;
-        SwapClip(BossMusicIntro[0]);
-        yield return new WaitForSeconds(.3f);
-        SwapClip(BossMusicLoop[0]);
-        yield return new WaitForSeconds(.3f);
-        SwapClip(StageMusicLoop[0]);
-        yield return new WaitForSeconds(.3f);
-
-        audioManager.FadeOutAudio();
-        
-        if(playMenuMusic) SwapClip(MenuMusic);
-        else PlayStageMusic();
-
-        yield return new WaitForSeconds(fadeDuration);
-        audioManager.musicSource.mute = false;
-        audioManager.FadeInAudio();
-    }
-
-
-    private void SwapMusic(AudioClip newMusic)
-    {
-        StartCoroutine(TransitionMusic(newMusic));
+        if(TransitionCoroutine != null) StopCoroutine(TransitionCoroutine);
+        TransitionCoroutine = StartCoroutine(TransitionMusic(newMusic));
     }
 
     IEnumerator TransitionMusic(AudioClip newMusic)
@@ -118,11 +52,12 @@ public class PlayMusic : MonoBehaviour
         audioManager.FadeOutAudio();
 
         yield return new WaitForSeconds(fadeDuration);
+        musicIntroAudioSource.Stop();
 
-        musicAudioSource.loop = true;
         SwapClip(newMusic);
 
         audioManager.FadeInAudio();
+        musicAudioSource.loop = true;
     }
 
     private void SwapClip(AudioClip newMusic)
@@ -135,56 +70,66 @@ public class PlayMusic : MonoBehaviour
 #region Boss Music: Intro -> Loop
     private void SwapIntroLoopMusic(AudioClip introClip, float introLength, AudioClip loopClip)
     {
+        if(TransitionCoroutine != null) StopCoroutine(TransitionCoroutine);
         TransitionCoroutine = StartCoroutine(TransitionMusic_IntroLoop(introClip, introLength, loopClip));
     }
 
-    IEnumerator TransitionMusic_IntroLoop(AudioClip newMusic, float introLength, AudioClip loopClip)
+    IEnumerator TransitionMusic_IntroLoop(AudioClip introClip, float introLength, AudioClip loopClip)
     {
         audioManager.FadeOutAudio();
 
         yield return new WaitForSeconds(fadeDuration);
 
-        // musicAudioSource.loop = true;
-        SwapClip(newMusic);
+        musicAudioSource.loop = false;
+        musicAudioSource.Stop();
+        musicIntroAudioSource.Stop();
 
+        yield return new WaitForSeconds(.1f); //short delay before setting loop to true
+        
+        //Switch to intro clip
+        musicIntroAudioSource.clip = introClip;
+
+        //Get duration of intro clip
+        musicDuration = (double)introClip.samples / introClip.frequency;
+
+        musicIntroAudioSource.PlayScheduled(0);//Starting intro clip
+        scheduledTime = AudioSettings.dspTime + musicDuration; //Get current time + duration
+        
         audioManager.FadeInAudio();
-        // Invoke("StartBossMusicLoop", BossMusicIntro[0].length); //.length not returning correct value
-        // yield return new WaitForSecondsRealtime(17.145f);
-        // yield return new WaitForSecondsRealtime(BossMusicIntroLength[index]);
-        yield return new WaitForSeconds(introLength);
-        // StartBossMusicLoop();
-        SwapClip(loopClip);
+
+        musicAudioSource.clip = loopClip; //load loop clip
+        musicAudioSource.PlayScheduled(scheduledTime); //wait for intro to end to play
+        musicAudioSource.loop = true;
     }
 #endregion
 
+#region Public Calls
     public void PlayBossMusic()
     {
         SwapIntroLoopMusic(BossMusicIntro[0], BossMusicIntroLength[0], BossMusicLoop[0]);
-        // Invoke("StartBossMusicLoop", BossMusicIntro[0].length);
     }
 
     private void StartBossMusicLoop()
     {
-        SwapClip(BossMusicLoop[0]);
+        PlayBossMusic();
     }
 
     public void PlayMenuMusic()
     {
-        SwapClip(MenuMusic);
+        // musicIntroAudioSource.Stop();
+
+        if(TransitionCoroutine != null) StopCoroutine(TransitionCoroutine);
+        SwapMusic(MenuMusic);
     }
 
     public void PlayStageMusic()
     {
-        // SwapClip(MenuMusic); //TODO: MenuMusic placeholder until separate InGame music
-        // SwapClip(GameMusicIntro[0]);
         SwapIntroLoopMusic(StageMusicIntro[0], StageMusicIntroLength[0], StageMusicLoop[0]);
     }
 
     public void TransitionBossMusicToNormal()
     {
-        SwapMusic(StageMusicLoop[0]);
-        // PlayStageMusic();
-        if(TransitionCoroutine != null) StopCoroutine(TransitionCoroutine);
+        PlayStageMusic();
     }
-    
+#endregion
 }

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -112,6 +112,7 @@ public class AugmentPool : MonoBehaviour
         else
         {
             // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
+            // TODO: rare bug here
             SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);
             augmentInventory.AddAugment(chosenAugment);
             augmentInventory.AddConditionalAugment(chosenAugment);

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -112,7 +112,12 @@ public class AugmentPool : MonoBehaviour
         else
         {
             // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
-            // TODO: rare bug here
+            // TODO: rare bug here, missing reference to augment? or ownedAugments
+            if(chosenAugment == null) Debug.Log("ChooseAugment - chosenAugment is null");
+            if(ownedAugments == null) Debug.Log("ChooseAugment - ownedAugments is null");
+            if(GetAugmentList(chosenAugment) == null) Debug.Log("ChooseAugment - GetAugmentList is null");
+            // bug testing ----------------
+
             SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);
             augmentInventory.AddAugment(chosenAugment);
             augmentInventory.AddConditionalAugment(chosenAugment);
@@ -147,7 +152,6 @@ public class AugmentPool : MonoBehaviour
         //'sellingDuplicates' allow multiple shops to list the same unowned Augment
         if(sellingDuplicates) SwapAugmentList(augment, GetAugmentList(augment), listedAugmentsTEMP);
         else SwapAugmentList(augment, ownedAugments, listedAugmentsTEMP);
-        
     }
 
     private List<AugmentScript> GetAugmentList(AugmentScript augment)

--- a/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs
+++ b/_Enemy Scripts/Enemy Behaviors/Dagger_Lunge.cs
@@ -66,6 +66,7 @@ public class Dagger_Lunge : Base_CombatBehavior
         
         combat.isAttacking = true;
         combat.altAttacking = true;
+        canAttack = false;
         combat.chasePlayer = false;
 
         yield return new WaitForSeconds(lungeDelay);
@@ -74,7 +75,7 @@ public class Dagger_Lunge : Base_CombatBehavior
         
         yield return new WaitForSeconds(chargeUpAnimDelay);
 
-        movement.ToggleFlip(false);
+        // movement.ToggleFlip(false);
 
         // combat.Lunge(movement.isFacingRight, 8); //Doesn't work, using GetKnockback()
         combat.animator.PlayManualAnim(0, fullAnimTimes[0]); //Start animation just before lunge
@@ -105,6 +106,7 @@ public class Dagger_Lunge : Base_CombatBehavior
 
         combat.isAttacking = false;
         combat.altAttacking = false;
+        canAttack = true;
         movement.canMove = true;
         combat.chasePlayer = true;
 
@@ -117,6 +119,7 @@ public class Dagger_Lunge : Base_CombatBehavior
     {
         combat.isAttacking = true;
         combat.altAttacking = true;
+        canAttack = false;
         movement.canMove = false;
         combat.chasePlayer = false;
 
@@ -134,6 +137,7 @@ public class Dagger_Lunge : Base_CombatBehavior
 
         combat.isAttacking = false;
         combat.altAttacking = false;
+        canAttack = true;
         movement.canMove = true;
         combat.chasePlayer = true;
 

--- a/_Level_Scene_Load/AsyncLevelLoader.cs
+++ b/_Level_Scene_Load/AsyncLevelLoader.cs
@@ -52,15 +52,15 @@ public class AsyncLevelLoader : MonoBehaviour
             InitialLoadScene();
     }
 
-    void Update()
-    {
-        //TODO: TESTING LEVEL RESET
-        if(Input.GetKeyDown(KeyCode.N))
-        {
-            // StartCoroutine(ResetRun());
-            ResetRun();
-        }
-    }
+    // void Update()
+    // {
+    //     //TODO: TESTING LEVEL RESET
+    //     if(Input.GetKeyDown(KeyCode.N))
+    //     {
+    //         // StartCoroutine(ResetRun());
+    //         ResetRun();
+    //     }
+    // }
 
 #region Reset Run
     public void ResetRun()
@@ -84,7 +84,6 @@ public class AsyncLevelLoader : MonoBehaviour
             yield return null;
         }
 
-        AudioManager.Instance.playMusic.AudioIngameSetup(false);
         // AudioManager.Instance.FadeInAudio();
         GameManager.Instance.TogglePlayerInput(true);
 
@@ -100,7 +99,6 @@ public class AsyncLevelLoader : MonoBehaviour
 
     IEnumerator InitialLoadCO()
     {
-        // LoadScreenAnim.SetTrigger("StartLoop");
         yield return new WaitForSeconds(.1f);
         yield return EndLoadingCO();
     }
@@ -261,7 +259,7 @@ public class AsyncLevelLoader : MonoBehaviour
     public void LoadMainMenu(string sceneToUnload) //String param not needed
     {
         AudioManager.Instance.FadeOutAudio();
-        GameManager.Instance.TogglePlayerInput(false);
+        if(GameManager.Instance != null) GameManager.Instance.TogglePlayerInput(false);
         StartCoroutine(LoadMainMenuCO(sceneToUnload));
     }
 
@@ -316,7 +314,7 @@ public class AsyncLevelLoader : MonoBehaviour
         // yield return new WaitForSecondsRealtime(1.5f);
         LoadScreenAnim.Play(loadingEndAnim);
         LoadingText.SetActive(false);
-        GameManager.Instance.TogglePlayerInput(true);
+        if(GameManager.Instance != null) GameManager.Instance.TogglePlayerInput(true);
         yield return new WaitForSecondsRealtime(loadScreenFadeInDuration);
     }
 }

--- a/_Level_Scene_Load/AsyncLevelLoader.cs
+++ b/_Level_Scene_Load/AsyncLevelLoader.cs
@@ -84,7 +84,7 @@ public class AsyncLevelLoader : MonoBehaviour
             yield return null;
         }
 
-        AudioManager.Instance.playMusic.AudioIngameSetup();
+        AudioManager.Instance.playMusic.AudioIngameSetup(false);
         // AudioManager.Instance.FadeInAudio();
         GameManager.Instance.TogglePlayerInput(true);
 
@@ -251,7 +251,10 @@ public class AsyncLevelLoader : MonoBehaviour
         // LoadingText.SetActive(false);
 
         // GameManager.Instance.TogglePlayerInput(true);
-        AudioManager.Instance.FadeInAudio();
+
+        yield return new WaitForSeconds(.3f);
+        AudioManager.Instance.playMusic.PlayStageMusic();
+        // AudioManager.Instance.FadeInAudio();
     }
 
     //

--- a/_Manager Handler Scripts/GameManager.cs
+++ b/_Manager Handler Scripts/GameManager.cs
@@ -10,6 +10,7 @@ public class GameManager : MonoBehaviour
     public bool inputAllowed;
     public bool shopOpen;
     public bool rewardOpen;
+    public bool respawnPromptOpen;
     public PauseMenu Pause;
 
     [Space(10)]
@@ -54,6 +55,7 @@ public class GameManager : MonoBehaviour
 
         shopOpen = false;
         rewardOpen = false;
+        respawnPromptOpen = false;
         inputAllowed = true;
         normalRoomClearCount = 0;
         roomAugmentRewardsGiven = 0;
@@ -148,6 +150,8 @@ public class GameManager : MonoBehaviour
     {
         if(respawnPrompt == null) return;
         respawnPrompt.SetActive(toggle);
+        respawnPromptOpen = toggle;
+        TogglePlayerInput(!toggle); //Screen enabled, disable input
     }
 
 #region Button Functions

--- a/_UI Scripts/PauseMenu.cs
+++ b/_UI Scripts/PauseMenu.cs
@@ -32,7 +32,7 @@ public class PauseMenu : MonoBehaviour
                 if(!pauseMenuUI.activeSelf)
                 {
                     // if(!GameManager.Instance.shopOpen) return;
-                    if(GameManager.Instance.rewardOpen) return;
+                    if(GameManager.Instance.rewardOpen || GameManager.Instance.respawnPromptOpen) return;
                 }
             }
             if (GameIsPaused)
@@ -78,9 +78,7 @@ public class PauseMenu : MonoBehaviour
     {
         //Load TutorialStage or FirstStage instead, Restart Run
         AsyncLevelLoader.asyncLevelLoader.StartGame("Tileset1_LevelGen", currentStage);
-        //!TODO: doesn't work 
-
-        //!!TODO: use same approach as LoadPlayer, isn't working now because it doesn't load the duplicate stage
+        //! doesn't work, use AsyncLevelLoader.ResetRun();
         
         Resume();
     }
@@ -90,11 +88,7 @@ public class PauseMenu : MonoBehaviour
         Time.timeScale = 1f;
         GameIsPaused = false;
         
-        // SceneManager.LoadScene("MainMenu"); //TODO; replace 
-
-        
         AsyncLevelLoader.asyncLevelLoader.LoadMainMenu("Tileset1_LevelGen");
-
 
         //SceneManager.LoadScene(0);
     }

--- a/_UI Scripts/PauseMenu.cs
+++ b/_UI Scripts/PauseMenu.cs
@@ -55,6 +55,7 @@ public class PauseMenu : MonoBehaviour
         Time.timeScale = 1f;
         GameIsPaused = false;
         GameManager.Instance.TogglePlayerInput(true);
+        AudioManager.Instance.musicSource.UnPause();
     }
 
     void Pause()
@@ -63,6 +64,7 @@ public class PauseMenu : MonoBehaviour
         Time.timeScale = 0f;
         GameIsPaused = true;
         GameManager.Instance.TogglePlayerInput(false);
+        AudioManager.Instance.musicSource.Pause();
     }
 
     public void PauseTimeOnly()


### PR DESCRIPTION
### Music/Audio
- Added second music audio source for Intro clips and Loop clips
  - Using PlayScheduled for more precise transition timings
- Added music fade transitions between Menu, Stage, and Boss

### Enemies
- Changed color of Grenade delayed explosion and projectile trail
- Increased hitbox width of Dagger ranged attack

### Augments
- Increased area of Combustion and Smite
- Increased proc chance of Augments
  - On-Kill effects are almost guaranteed instead of previous 30%
- Parry effects have higher chance to proc

### Misc
- Added check to prevent pausing when Respawn Prompt is enabled