### PR TITLE
v0.16 - Boss update, WebGL fix

### DIFF
--- a/_Audio/PlayAudioClips.cs
+++ b/_Audio/PlayAudioClips.cs
@@ -45,7 +45,7 @@ public class PlayAudioClips : MonoBehaviour
 
     public void PlayAttackSwing()
     {
-        if(charAttackSwing.Length == 0) return;
+        if(charAttackSwing.Length == 0 || audioManager == null) return;
         int randIndex = Random.Range(0, charAttackSwing.Length);
 
         if(isPlayer) audioManager.PlayAtkSound_Player(charAttackSwing[randIndex]);
@@ -54,14 +54,14 @@ public class PlayAudioClips : MonoBehaviour
 
     public void PlayFootsteps()
     {
-        if(charFootsteps.Length == 0) return;
+        if(charFootsteps.Length == 0 || audioManager == null) return;
         int randIndex = Random.Range(0, charFootsteps.Length);
         audioManager.PlayAtkSound_Player(charFootsteps[randIndex]);
     }
 
     public void PlayJump()
     {
-        if(jumpSound.Length == 0) return;
+        if(jumpSound.Length == 0 || audioManager == null) return;
         int randIndex = Random.Range(0, jumpSound.Length);
         audioManager.PlayAtkSound_Player(jumpSound[randIndex]);
     }
@@ -72,7 +72,7 @@ public class PlayAudioClips : MonoBehaviour
 
     public void PlayHitAudio()
     {
-        if(hitAudio.Length == 0) return;
+        if(hitAudio.Length == 0 || audioManager == null) return;
         int randIndex = Random.Range(0, hitAudio.Length);
 
         if(isPlayer) audioManager.PlayHitSound_Player(hitAudio[randIndex]);
@@ -81,7 +81,7 @@ public class PlayAudioClips : MonoBehaviour
 
     public void PlayBlockedAudio()
     {
-        if(blockedHit.Length == 0) return;
+        if(blockedHit.Length == 0 || audioManager == null) return;
         int randIndex = Random.Range(0, blockedHit.Length);
 
         if(isPlayer) audioManager.PlayBlockSound_Player(blockedHit[randIndex]);
@@ -90,7 +90,7 @@ public class PlayAudioClips : MonoBehaviour
 
     public void PlayDeathSound()
     {
-        if(deathSound.Length == 0) return;
+        if(deathSound.Length == 0 || audioManager == null) return;
         int randIndex = Random.Range(0, deathSound.Length);
 
         if(isPlayer) audioManager.PlayDeathSound_Player(deathSound[randIndex]);

--- a/_Augments/AugmentDisplay.cs
+++ b/_Augments/AugmentDisplay.cs
@@ -51,7 +51,7 @@ public class AugmentDisplay : MonoBehaviour
         randomizeLevel = false;
         if(augmentScript == null)
         {
-            Debug.Log("No Augment Scriptable Object referenced!");
+            // Debug.Log("No Augment Scriptable Object referenced!");
             return;
         }
         allowInput = false;

--- a/_Augments/AugmentInventory.cs
+++ b/_Augments/AugmentInventory.cs
@@ -61,7 +61,7 @@ public class AugmentInventory : MonoBehaviour
     public void OnKill(Transform enemyPosition, float addProcChance = 0)
     {
         //Currently being called in Base_EnemyCombat
-        Debug.Log("OnKill");
+        // Debug.Log("OnKill");
         if(onKillAugments.Count <= 0) return;
         for(int i=0; i<onKillAugments.Count; i++)
         {
@@ -71,7 +71,7 @@ public class AugmentInventory : MonoBehaviour
 
     public void OnDamageTaken()
     {
-        Debug.Log("OnDamageTaken");
+        // Debug.Log("OnDamageTaken");
         if(onDamageTakenAugments.Count <= 0) return;
         for(int i=0; i<onDamageTakenAugments.Count; i++)
         {
@@ -81,7 +81,7 @@ public class AugmentInventory : MonoBehaviour
 
     public void OnHit(float addProcChance = 0)
     {
-        Debug.Log("OnHit");
+        // Debug.Log("OnHit");
         if(onHitAugments.Count <= 0) return;
         for(int i=0; i<onHitAugments.Count; i++)
         {
@@ -91,7 +91,7 @@ public class AugmentInventory : MonoBehaviour
 
     public void OnHit(Transform objectHitPos, float addProcChance = 0)
     {
-        Debug.Log("OnHit position");
+        // Debug.Log("OnHit position");
         if(onHitAugments.Count <= 0) return;
         for(int i=0; i<onHitAugments.Count; i++)
         {
@@ -103,7 +103,7 @@ public class AugmentInventory : MonoBehaviour
 
     public void OnParry(Transform objectHitPos, float addProcChance = 0)
     {
-        Debug.Log("On Parry");
+        // Debug.Log("On Parry");
         if(onParryAugments.Count <= 0) return;
         for(int i=0; i<onParryAugments.Count; i++)
         {
@@ -113,7 +113,7 @@ public class AugmentInventory : MonoBehaviour
 
     public void OnRoomClear()
     {
-        Debug.Log("OnRoomClear");
+        // Debug.Log("OnRoomClear");
         if(onRoomClearAugments.Count <= 0) return;
         for(int i=0; i<onRoomClearAugments.Count; i++)
         {

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -90,6 +90,9 @@ public class AugmentPool : MonoBehaviour
     public void SwapAugmentList(AugmentScript addedAugment, List<AugmentScript> currList, List<AugmentScript> newList)
     {
         //Moves an Augment from one list to another
+
+        //TODO: is Add/Remove bad practice ???, maybe reference is lost with Remove?
+            //could add a copy here: AugmentScript temp = addedAugment
         newList.Add(addedAugment);
         currList.Remove(addedAugment);
 
@@ -114,10 +117,17 @@ public class AugmentPool : MonoBehaviour
             // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
             // TODO: rare bug here, missing reference to augment? or ownedAugments
             // - 11/27: chosenAugment null ref
-            if(chosenAugment == null) Debug.Log("AugmentPool.ChooseAugment ERROR - chosenAugment is null");
+            // if(chosenAugment == null) Debug.Log("AugmentPool.ChooseAugment ERROR - chosenAugment is null");
+            if(chosenAugment == null)
+            {
+                Debug.Log("AugmentPool.chosenAugment NULL ref: " + gameObject.name);
+                return;
+            }
+            
             if(ownedAugments == null) Debug.Log("AugmentPool.ChooseAugment ERROR - ownedAugments is null");
             if(GetAugmentList(chosenAugment) == null) Debug.Log("AugmentPool.ChooseAugment ERROR - GetAugmentList is null");
             // bug testing ----------------
+
 
             SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);
             augmentInventory.AddAugment(chosenAugment);

--- a/_Augments/AugmentPool.cs
+++ b/_Augments/AugmentPool.cs
@@ -113,9 +113,10 @@ public class AugmentPool : MonoBehaviour
         {
             // chosenAugment.UpdateLevel(augmentLevel); //TODO: test: Manually updating level in case of duplicates
             // TODO: rare bug here, missing reference to augment? or ownedAugments
-            if(chosenAugment == null) Debug.Log("ChooseAugment - chosenAugment is null");
-            if(ownedAugments == null) Debug.Log("ChooseAugment - ownedAugments is null");
-            if(GetAugmentList(chosenAugment) == null) Debug.Log("ChooseAugment - GetAugmentList is null");
+            // - 11/27: chosenAugment null ref
+            if(chosenAugment == null) Debug.Log("AugmentPool.ChooseAugment ERROR - chosenAugment is null");
+            if(ownedAugments == null) Debug.Log("AugmentPool.ChooseAugment ERROR - ownedAugments is null");
+            if(GetAugmentList(chosenAugment) == null) Debug.Log("AugmentPool.ChooseAugment ERROR - GetAugmentList is null");
             // bug testing ----------------
 
             SwapAugmentList(chosenAugment, GetAugmentList(chosenAugment), ownedAugments);

--- a/_Augments/AugmentScript.cs
+++ b/_Augments/AugmentScript.cs
@@ -96,7 +96,7 @@ public class AugmentScript : MonoBehaviour
         UpdateLevel(AugmentLevel);
         UpdateConditional();
         UpdateDescription();
-        Debug.Log("Augment Stats loaded");
+        // Debug.Log("Augment Stats loaded");
     }
 //
     private void UpdateConditional()

--- a/_Augments/Conditional/Base_ConditionalAugments.cs
+++ b/_Augments/Conditional/Base_ConditionalAugments.cs
@@ -64,7 +64,7 @@ public class Base_ConditionalAugments : MonoBehaviour
 
     protected virtual void Activate()
     {
-        Debug.Log(name + " Augment Activated");
+        // Debug.Log(name + " Augment Activated");
         if(!CanActivate()) return;
         StartProcCooldown();
 

--- a/_Augments/Conditional/CA_IncreasedAttackSpeed.cs
+++ b/_Augments/Conditional/CA_IncreasedAttackSpeed.cs
@@ -60,7 +60,7 @@ public class CA_IncreasedAttackSpeed : Base_ConditionalAugments
     protected virtual void StopBuff()
     {
         active = false;
-        Debug.Log("ATTACKSPEED STOPPED");
+        // Debug.Log("ATTACKSPEED STOPPED");
         playerCombat.attackSpeed = baseAttackSpeed;
     }
 }

--- a/_Augments/Conditional/CA_Parry_OnHit.cs
+++ b/_Augments/Conditional/CA_Parry_OnHit.cs
@@ -25,7 +25,7 @@ public class CA_Parry_OnHit : Base_ConditionalAugments
 
     protected override void Activate(Transform objectHitPos)
     {
-        Debug.Log(name + " Augment activated");
+        // Debug.Log(name + " Augment activated");
         // base.Activate();
         if(!CanActivate()) return;
         StartProcCooldown();

--- a/_Enemy Scripts/Base_BossCombat.cs
+++ b/_Enemy Scripts/Base_BossCombat.cs
@@ -14,10 +14,14 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
     public bool canAttackFar;
     public bool canAttack;
 
+    [Space(10)]
+
     [Header("== Attack Phases ==")]
     [SerializeField] protected int[] Phase1AtkPool;
     [SerializeField] protected int[] Phase2AtkPool;
     [SerializeField] protected int[] Phase3AtkPool;
+
+    [Space(10)]
 
     [Header("=== References/Setup ===")]
     public LayerMask playerLayer;
@@ -97,6 +101,13 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
     protected bool changingPhase;
     [SerializeField] protected GameObject PhaseShield;
     [SerializeField] protected ToggleEffectAnimator PhaseShieldBreak;
+
+    [Space(10)]
+
+    [Header("=== Health Phase Adds ===")]
+    [SerializeField] protected GameObject[] AddWave;
+
+    [Space(10)]
 
     [Header("--- Attack Logic variables ---")]
     public bool attackClose;
@@ -413,6 +424,9 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         canAttack = false;
 
         CleanseDebuffs();
+
+        //Spawn Additionals
+        SpawnAddsWave();
         
         yield return new WaitForSeconds(1.5f);
         animator.PlayManualAnim(6, 1.083f); //Buff anim
@@ -439,6 +453,25 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
 
             if(currDebuff != null) currDebuff.CleanseDebuff();
             //make sure index is correct
+        }
+    }
+
+    protected void SpawnAddsWave()
+    {
+        if(AddWave[currentPhase-1] == null) return;
+        AddWave[currentPhase-1].SetActive(true);
+    }
+
+    protected void ClearAdds()
+    {
+        for(int i=0; i<AddWave.Length; i++)
+        {
+            int waveLength = AddWave[i].transform.childCount;
+            for(int j=0; j<waveLength; j++)
+            {
+                Base_EnemyCombat add = AddWave[i].transform.GetChild(j).GetComponent<Base_EnemyCombat>();
+                if(add != null) add.TakeDamageStatus(999, 3);
+            }
         }
     }
 
@@ -550,6 +583,8 @@ public class Base_BossCombat : MonoBehaviour, IDamageable
         healthBar.gameObject.SetActive(false);
         canAttack = false;
         isAlive = false;
+
+        ClearAdds();
 
         AudioManager.Instance.playMusic.TransitionBossMusicToNormal();
 

--- a/_Enemy Scripts/Base_EnemyController.cs
+++ b/_Enemy Scripts/Base_EnemyController.cs
@@ -236,7 +236,7 @@ public class Base_EnemyController : MonoBehaviour
     {
         if (combat.isAttacking)
         {
-            if (!raycast.isGrounded) //TODO: testing, no issues yet
+            if (!raycast.isGrounded)
                 if(movement.rb.velocity.y != 0) combat.StopAttack();
             return;
         } 

--- a/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
+++ b/_Enemy Scripts/ColossalBoss_EnemyCombat.cs
@@ -84,8 +84,8 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
     {
         isSpawning = true; //This prevents the enemy from attacking and taking damage
         
-        yield return new WaitForSeconds(delay);
         ExplosionInit(4);
+        yield return new WaitForSeconds(delay);
         
         animator.PlayManualAnim(4, 1f);
         yield return new WaitForSeconds(1f); //Wake animation
@@ -331,6 +331,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
         {
             ExplosionHandler.SpawnPrefab(castPos);
         }
+
         Invoke("ShakeEvent", .33f);
     }
 
@@ -595,7 +596,7 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
     
         changingPhase = true;
         //Stop Attack and AttackEnd Coroutines
-        StopAttack();        
+        StopAttack();
 
         //Toggle Shield gameobject and increase defenses
         PhaseShieldBreak.PlayAnim(0);
@@ -608,6 +609,9 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
         canAttack = false;
 
         CleanseDebuffs();
+
+        //Spawn Adds
+        SpawnAddsWave();
         
         yield return new WaitForSeconds(1.5f);
         animator.PlayManualAnim(6, 1.083f); //Buff anim
@@ -654,6 +658,8 @@ public class ColossalBoss_EnemyCombat : Base_BossCombat
         StopAllCoroutines();
         canAttack = false;
         // StopAllCoroutines();
+
+        ClearAdds();
 
         //Boomerang/Melee Spin attack cancel
         if(BoomerangArms.activeInHierarchy) BoomerangArms.SetActive(false);

--- a/_Level Generator/LevelBuilder.cs
+++ b/_Level Generator/LevelBuilder.cs
@@ -72,6 +72,8 @@ public class LevelBuilder : MonoBehaviour
         // playerStartingPos = player.position;
         cameraManager = GameObject.FindGameObjectWithTag("GameManager").GetComponentInChildren<CameraRoomManager>();
 
+        // cameraManager = GameManager.Instance.cameraRoomManager;
+
         DeleteOrigins();
         GameManager.Instance.RestartLevelCount();
     }
@@ -169,7 +171,7 @@ public class LevelBuilder : MonoBehaviour
         if(LevelGenBoundaries != null) LevelGenBoundaries.SetActive(false);
 
         yield return new WaitForSecondsRealtime(.1f);
-        Debug.Log("Origins Generated");
+        // Debug.Log("Origins Generated");
     }
 
     private void Move()

--- a/_Level_Scene_Load/AsyncLevelLoader.cs
+++ b/_Level_Scene_Load/AsyncLevelLoader.cs
@@ -83,9 +83,9 @@ public class AsyncLevelLoader : MonoBehaviour
         //Loading in Single mode unloads all other scenes
         var mainScene = SceneManager.LoadSceneAsync("MainMenu", LoadSceneMode.Single);
         
+        Debug.Log("Loading MainMenu...");
         while(!mainScene.isDone)
         {
-            Debug.Log("Loading MainMenu...");
             yield return null;
         }
 
@@ -205,7 +205,6 @@ public class AsyncLevelLoader : MonoBehaviour
 
         while (!playerScene.isDone)
         {
-            Debug.Log("loading player");
             yield return null;
         }
 
@@ -240,9 +239,9 @@ public class AsyncLevelLoader : MonoBehaviour
         LoadPlayer();
         allowLoad = false;
 
+        Debug.Log("Loading Player...");
         while (!playerLoaded)
         {
-            Debug.Log("loading player");
             yield return null;
         }
 
@@ -252,10 +251,10 @@ public class AsyncLevelLoader : MonoBehaviour
         LoadScene(startStage);
         // allowLoad = true;
 
+        Debug.Log("Building Level...");
         while(!allowLoad)
         {
             //allowLoad set to true once level generation is done
-            Debug.Log("Building Level...");
             yield return null;
         }
 

--- a/_Level_Scene_Load/CameraAnchorHandler.cs
+++ b/_Level_Scene_Load/CameraAnchorHandler.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CameraAnchorHandler : MonoBehaviour
+{
+    void Start()
+    {
+        //GameManager scene is loaded before this scene, set anchor one this scene is loaded
+        GameManager.Instance.cameraRoomManager.SetCameraAnchor();
+    }
+}

--- a/_Level_Scene_Load/CameraAnchorHandler.cs.meta
+++ b/_Level_Scene_Load/CameraAnchorHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0964665e787b946419627cbda14da9d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/_Level_Scene_Load/EnemyStageManager.cs
+++ b/_Level_Scene_Load/EnemyStageManager.cs
@@ -91,7 +91,7 @@ public class EnemyStageManager : MonoBehaviour
 #region Spawning
     public void SpawnEnemies()
     {
-        Debug.Log("Player entered room " + name);
+        // Debug.Log("Player entered room " + name);
         //Called by default, when Player enters room
         if(trialRoom) return;
         SpawnCurrentWave();

--- a/_Manager Handler Scripts/GameManager.cs
+++ b/_Manager Handler Scripts/GameManager.cs
@@ -15,6 +15,9 @@ public class GameManager : MonoBehaviour
     public PauseMenu Pause;
 
     [Space(10)]
+    public CameraRoomManager cameraRoomManager;
+
+    [Space(10)]
     [Header("- Player/Enemy References -")]
     public Transform playerTransform;
     public Base_PlayerMovement PlayerMovement;
@@ -57,6 +60,7 @@ public class GameManager : MonoBehaviour
         PlayerCombat = playerTransform.GetComponent<Base_PlayerCombat>();
         playerTargetOffset = GameObject.FindGameObjectWithTag("PlayerTargetOffset").transform;
         if (Inventory == null) Inventory = GetComponent<Inventory>();
+        if (cameraRoomManager == null) cameraRoomManager = GetComponentInChildren<CameraRoomManager>();
 
         shopOpen = false;
         rewardOpen = false;

--- a/_Manager Handler Scripts/Room Managers/CameraRoomManager.cs
+++ b/_Manager Handler Scripts/Room Managers/CameraRoomManager.cs
@@ -6,6 +6,9 @@ public class CameraRoomManager : MonoBehaviour
 {
     //Moves Camera to the Player's current room
     //! - Attach to Origin Child object with collider
+    [Header("- Player Scene Only -")]
+    [SerializeField] bool inPlayerScene = false;
+    [Space(20)]
 
     [Header("References")]
     [SerializeField] public Transform CameraAnchor;
@@ -17,18 +20,27 @@ public class CameraRoomManager : MonoBehaviour
 
     void Start()
     {
-        CameraAnchor = GameObject.FindGameObjectWithTag("CameraAnchor").transform;
+        if(!inPlayerScene)
+        {
+            SetCameraAnchor();
+        }
+
         originPosition = GetComponentInParent<Transform>().position;
-        yOffset = CameraAnchor.position.y; //This is the offset since camera starts at 0
         
         if(doorManager == null) doorManager = GetComponentInParent<DoorManager>();
         if(roomClear == null) roomClear = GetComponentInParent<RoomClear>();
     }
 
-    void Update()
+    // void FixedUpdate()
+    // {
+    //     //may need to add another check to see if camera is in the correct room
+    //     // if(CameraAnchor == null) CameraAnchor = GameObject.FindGameObjectWithTag("CameraAnchor").transform; //TODO: gamemanager test
+    // }
+
+    public void SetCameraAnchor()
     {
-        //may need to add another check to see if camera is in the correct room
-        if(CameraAnchor == null) CameraAnchor = GameObject.FindGameObjectWithTag("CameraAnchor").transform;
+        CameraAnchor = GameObject.FindGameObjectWithTag("CameraAnchor").transform;
+        yOffset = CameraAnchor.position.y;
     }
 
     void OnTriggerEnter2D(Collider2D collision)
@@ -36,7 +48,7 @@ public class CameraRoomManager : MonoBehaviour
         if(collision.CompareTag("Player"))
         {
             RelocateCamera();
-            playerIsHere = true; //TODO: may have a use, currently debugging
+            playerIsHere = true; //Debugging
             roomClear.ToggleMinimapIcon(true);
             doorManager.UpdateDoorState(.05f); //Open/Close doors if room has been cleared
         }
@@ -50,7 +62,6 @@ public class CameraRoomManager : MonoBehaviour
 
     void OnTriggerExit2D(Collider2D collision)
     {
-        //
         playerIsHere = false;
     }
 

--- a/_Manager Handler Scripts/Room Managers/RoomClear.cs
+++ b/_Manager Handler Scripts/Room Managers/RoomClear.cs
@@ -63,7 +63,7 @@ public class RoomClear : MonoBehaviour
     public void Cleared()
     {
         //TimeManager.Instance.DoFreezeTime(.15f, .05f);
-        Debug.Log("Room Cleared");
+        // Debug.Log("Room Cleared");
         GameManager.Instance.AugmentInventory.OnRoomClear();
         StartCoroutine(DelayClear());
         //if this breaks, update enemyCount with enemyCount = EnemyList.transform.childCount

--- a/_UI Scripts/PauseMenu.cs
+++ b/_UI Scripts/PauseMenu.cs
@@ -57,9 +57,15 @@ public class PauseMenu : MonoBehaviour
         Time.timeScale = 1f;
         GameIsPaused = false;
         GameManager.Instance.TogglePlayerInput(true);
-        AudioManager.Instance.musicSource.UnPause();
-        AudioManager.Instance.musicSource2.UnPause();
-        AudioListener.pause = false;
+
+        #if UNITY_WEBGL
+            AudioManager.Instance.musicSource.mute = false;
+            AudioManager.Instance.musicSource2.mute = false;
+        #else
+            AudioManager.Instance.musicSource.UnPause();
+            AudioManager.Instance.musicSource2.UnPause();
+            AudioListener.pause = false;
+        #endif
     }
 
     void Pause()
@@ -68,9 +74,15 @@ public class PauseMenu : MonoBehaviour
         Time.timeScale = 0f;
         GameIsPaused = true;
         GameManager.Instance.TogglePlayerInput(false);
-        AudioManager.Instance.musicSource.Pause();
-        AudioManager.Instance.musicSource2.Pause();
-        AudioListener.pause = true;
+
+        #if UNITY_WEBGL
+            AudioManager.Instance.musicSource.mute = true;
+            AudioManager.Instance.musicSource2.mute = true;
+        #else
+            AudioManager.Instance.musicSource.Pause();
+            AudioManager.Instance.musicSource2.Pause();
+            AudioListener.pause = true;
+        #endif
     }
 
     public void PauseTimeOnly()


### PR DESCRIPTION
### Enemy 
- Added additional waves to Boss fight
  - Additional enemies spawn during the Boss health phase change
    - 1 Shielder during Phase 1
    - 1 Shielder, 1 Drone during Phase 2
  - All additionals are killed when the Boss is killed
- Shortened all knockup durations from enemy hits to .2s

### Misc
- Removed unneeded Debug logs
- Added CameraAnchor script to set reference when Level scene is loaded
- Added check for CameraRoomManager to only initialize the Player scene object
  - Setup for non-Player scene objects not needed

### Bugs
- Fixed audio timing issue with intro and looping transitions
  - WebGL can't pause dspTime to delay PlayScheduled
  - WebGL now only mutes audio when the game is paused